### PR TITLE
fix(vercel): use writable upload storage (/tmp) and unify public uploads path

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const path = require('path');
 const { errorHandler } = require('./middlewares/errorHandler');
 const { usersRouter } = require('./routes/users');
 const { establishmentsRouter } = require('./routes/establishments');
@@ -10,6 +9,7 @@ const { authRouter } = require('./routes/auth');
 const { swaggerSpec } = require('./config/swagger');
 const { adminRouter } = require('./routes/admin');
 const { healthRouter } = require('./routes/health');
+const { getUploadsBaseDir } = require('./utils/uploadStorage');
 const cors = require('cors');
 
 const app = express();
@@ -19,7 +19,7 @@ app.use(cors({
   origin: process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',').map(v => v.trim()) : true,
   credentials: true,
 }));
-app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+app.use('/uploads', express.static(getUploadsBaseDir()));
 
 app.get('/openapi.json', (req, res) => {
   res.json(swaggerSpec);

--- a/controllers/establishmentsController.js
+++ b/controllers/establishmentsController.js
@@ -1,9 +1,10 @@
-const path = require('path');
 const fs = require('fs/promises');
 const crypto = require('crypto');
+const path = require('path');
 const { establishmentService } = require('../services/establishmentService');
 const { ApiError } = require('../middlewares/errorHandler');
 const { isNonEmptyString, isValidUrl } = require('../utils/validation');
+const { getUploadDir, buildPublicUploadUrl } = require('../utils/uploadStorage');
 
 const ALLOWED_IMAGE_MIME = {
   'image/jpeg': 'jpg',
@@ -107,11 +108,11 @@ async function uploadEstablishmentImage(req, res, next) {
     const safeBaseName = (file_name || 'establishment').replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 40) || 'establishment';
     const fileName = `${safeBaseName}-${crypto.randomUUID()}.${extension}`;
 
-    const uploadDir = path.join(__dirname, '..', 'uploads', 'establishments');
+    const uploadDir = getUploadDir('establishments');
     await fs.mkdir(uploadDir, { recursive: true });
     await fs.writeFile(path.join(uploadDir, fileName), buffer);
 
-    const imageUrl = `${req.protocol}://${req.get('host')}/uploads/establishments/${fileName}`;
+    const imageUrl = buildPublicUploadUrl(req, 'establishments', fileName);
     res.status(201).json({ image_url: imageUrl });
   } catch (err) {
     next(err);

--- a/controllers/pointsConfigController.js
+++ b/controllers/pointsConfigController.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const { pointsConfigService } = require('../services/pointsConfigService');
 const { ApiError } = require('../middlewares/errorHandler');
 const { isNonEmptyString, isValidUrl } = require('../utils/validation');
+const { getUploadDir, buildPublicUploadUrl } = require('../utils/uploadStorage');
 
 const FIELDS = [
   'image_points_yes',
@@ -90,11 +91,11 @@ async function uploadDefaultAvatar(req, res, next) {
     const safeBaseName = (file_name || 'default-avatar').replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 40) || 'default-avatar';
     const fileName = `${safeBaseName}-${crypto.randomUUID()}.${extension}`;
 
-    const uploadDir = path.join(__dirname, '..', 'uploads', 'config');
+    const uploadDir = getUploadDir('config');
     await fs.mkdir(uploadDir, { recursive: true });
     await fs.writeFile(path.join(uploadDir, fileName), buffer);
 
-    const avatarUrl = `${req.protocol}://${req.get('host')}/uploads/config/${fileName}`;
+    const avatarUrl = buildPublicUploadUrl(req, 'config', fileName);
     const updated = await pointsConfigService.setDefaultUserAvatar(avatarUrl);
     res.status(201).json({ default_user_avatar_url: updated?.default_user_avatar_url || avatarUrl });
   } catch (err) {

--- a/controllers/reviewsController.js
+++ b/controllers/reviewsController.js
@@ -1,9 +1,10 @@
-const path = require('path');
 const fs = require('fs/promises');
 const crypto = require('crypto');
+const path = require('path');
 const { reviewService } = require('../services/reviewService');
 const { ApiError } = require('../middlewares/errorHandler');
 const { isNonEmptyString, isValidUuid, isPositiveNumber, isValidUrl } = require('../utils/validation');
+const { getUploadDir, buildPublicUploadUrl } = require('../utils/uploadStorage');
 
 const ALLOWED_IMAGE_MIME = {
   'image/jpeg': 'jpg',
@@ -124,11 +125,11 @@ async function uploadReviewEvidenceImage(req, res, next) {
     const safeBaseName = (file_name || 'review-evidence').replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 40) || 'review-evidence';
     const fileName = `${safeBaseName}-${crypto.randomUUID()}.${extension}`;
 
-    const uploadDir = path.join(__dirname, '..', 'uploads', 'reviews');
+    const uploadDir = getUploadDir('reviews');
     await fs.mkdir(uploadDir, { recursive: true });
     await fs.writeFile(path.join(uploadDir, fileName), buffer);
 
-    const imageUrl = `${req.protocol}://${req.get('host')}/uploads/reviews/${fileName}`;
+    const imageUrl = buildPublicUploadUrl(req, 'reviews', fileName);
     res.status(201).json({ image_url: imageUrl });
   } catch (err) {
     next(err);

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const { userService } = require('../services/userService');
 const { ApiError } = require('../middlewares/errorHandler');
 const { isNonEmptyString, isValidEmail, isValidUrl } = require('../utils/validation');
+const { getUploadDir, buildPublicUploadUrl } = require('../utils/uploadStorage');
 
 const ALLOWED_AVATAR_MIME = {
   'image/jpeg': 'jpg',
@@ -137,11 +138,11 @@ async function uploadMyAvatar(req, res, next) {
     const safeBaseName = (file_name || 'avatar').replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 40) || 'avatar';
     const fileName = `${safeBaseName}-${crypto.randomUUID()}.${extension}`;
 
-    const uploadDir = path.join(__dirname, '..', 'uploads', 'avatars');
+    const uploadDir = getUploadDir('avatars');
     await fs.mkdir(uploadDir, { recursive: true });
     await fs.writeFile(path.join(uploadDir, fileName), buffer);
 
-    const avatarUrl = `${req.protocol}://${req.get('host')}/uploads/avatars/${fileName}`;
+    const avatarUrl = buildPublicUploadUrl(req, 'avatars', fileName);
     res.status(201).json({ avatar_url: avatarUrl });
   } catch (err) {
     next(err);

--- a/utils/uploadStorage.js
+++ b/utils/uploadStorage.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+function getUploadsBaseDir() {
+  if (process.env.UPLOAD_DIR) {
+    return process.env.UPLOAD_DIR;
+  }
+  if (process.env.VERCEL) {
+    return '/tmp/uploads';
+  }
+  return path.join(process.cwd(), 'uploads');
+}
+
+function getUploadDir(scope) {
+  return path.join(getUploadsBaseDir(), scope);
+}
+
+function buildPublicUploadUrl(req, scope, fileName) {
+  return `${req.protocol}://${req.get('host')}/uploads/${scope}/${fileName}`;
+}
+
+module.exports = {
+  getUploadsBaseDir,
+  getUploadDir,
+  buildPublicUploadUrl,
+};


### PR DESCRIPTION
- Add upload storage helper with environment-aware base dir:
  - Vercel: /tmp/uploads
  - local: <cwd>/uploads
  - optional override via UPLOAD_DIR
- Serve /uploads from dynamic storage base in app.js
- Refactor upload controllers to use centralized storage/url helpers:
  - users (avatars)
  - establishments (images)
  - reviews (evidence)
  - points config (default avatar)

This fixes ENOENT mkdir '/var/task/uploads' when uploading files on Vercel.