### PR TITLE
fix(storage): persist uploads on Vercel using Cloudinary with local fallback

### DIFF
--- a/controllers/reviewsController.js
+++ b/controllers/reviewsController.js
@@ -1,10 +1,8 @@
-const fs = require('fs/promises');
 const crypto = require('crypto');
-const path = require('path');
 const { reviewService } = require('../services/reviewService');
+const { uploadImageDataUrl } = require('../services/fileStorageService');
 const { ApiError } = require('../middlewares/errorHandler');
 const { isNonEmptyString, isValidUuid, isPositiveNumber, isValidUrl } = require('../utils/validation');
-const { getUploadDir, buildPublicUploadUrl } = require('../utils/uploadStorage');
 
 const ALLOWED_IMAGE_MIME = {
   'image/jpeg': 'jpg',
@@ -125,11 +123,12 @@ async function uploadReviewEvidenceImage(req, res, next) {
     const safeBaseName = (file_name || 'review-evidence').replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 40) || 'review-evidence';
     const fileName = `${safeBaseName}-${crypto.randomUUID()}.${extension}`;
 
-    const uploadDir = getUploadDir('reviews');
-    await fs.mkdir(uploadDir, { recursive: true });
-    await fs.writeFile(path.join(uploadDir, fileName), buffer);
-
-    const imageUrl = buildPublicUploadUrl(req, 'reviews', fileName);
+    const imageUrl = await uploadImageDataUrl(req, {
+      scope: 'reviews',
+      fileName,
+      dataUrl: data_url,
+      buffer,
+    });
     res.status(201).json({ image_url: imageUrl });
   } catch (err) {
     next(err);

--- a/docs/DEPLOY_VERCEL.md
+++ b/docs/DEPLOY_VERCEL.md
@@ -16,6 +16,16 @@ Set these in Vercel Project Settings → Environment Variables:
 - `PRIVATE_KEY`
 - `CONTRACT_ADDRESS`
 - `BASE_URL` = `https://syspoints-dev.vercel.app`
+- `CORS_ORIGIN` = `https://syspoints.vercel.app,http://localhost:5173`
+- `PGPOOL_MAX` = `1`
+
+### Persistent image storage (recommended on Vercel)
+To avoid losing images between serverless instances, configure Cloudinary:
+
+- `CLOUDINARY_CLOUD_NAME`
+- `CLOUDINARY_API_KEY`
+- `CLOUDINARY_API_SECRET`
+- `CLOUDINARY_FOLDER` (optional, default: `syspoints`)
 
 ## 3. Vercel Config
 The repository includes `vercel.json`:

--- a/services/fileStorageService.js
+++ b/services/fileStorageService.js
@@ -1,0 +1,72 @@
+const fs = require('fs/promises');
+const path = require('path');
+const crypto = require('crypto');
+const { getUploadDir, buildPublicUploadUrl } = require('../utils/uploadStorage');
+
+function getCloudinaryConfig() {
+  const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
+  const apiKey = process.env.CLOUDINARY_API_KEY;
+  const apiSecret = process.env.CLOUDINARY_API_SECRET;
+
+  if (!cloudName || !apiKey || !apiSecret) {
+    return null;
+  }
+
+  return {
+    cloudName,
+    apiKey,
+    apiSecret,
+    folderRoot: process.env.CLOUDINARY_FOLDER || 'syspoints',
+  };
+}
+
+async function uploadToCloudinary({ scope, fileName, dataUrl, cloudinary }) {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const folder = `${cloudinary.folderRoot}/${scope}`;
+  const publicId = String(fileName || 'asset')
+    .replace(/\.[a-zA-Z0-9]+$/, '')
+    .replace(/[^a-zA-Z0-9/_-]/g, '')
+    .slice(0, 120) || `asset-${timestamp}`;
+
+  const signatureBase = `folder=${folder}&public_id=${publicId}&timestamp=${timestamp}${cloudinary.apiSecret}`;
+  const signature = crypto.createHash('sha1').update(signatureBase).digest('hex');
+
+  const body = new URLSearchParams({
+    file: dataUrl,
+    api_key: cloudinary.apiKey,
+    timestamp: String(timestamp),
+    signature,
+    folder,
+    public_id: publicId,
+  });
+
+  const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudinary.cloudName}/image/upload`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || !payload?.secure_url) {
+    const detail = payload?.error?.message || `Cloudinary upload failed with status ${response.status}`;
+    throw new Error(detail);
+  }
+
+  return payload.secure_url;
+}
+
+async function uploadImageDataUrl(req, { scope, fileName, dataUrl, buffer }) {
+  const cloudinary = getCloudinaryConfig();
+  if (cloudinary) {
+    return uploadToCloudinary({ scope, fileName, dataUrl, cloudinary });
+  }
+
+  const uploadDir = getUploadDir(scope);
+  await fs.mkdir(uploadDir, { recursive: true });
+  await fs.writeFile(path.join(uploadDir, fileName), buffer);
+  return buildPublicUploadUrl(req, scope, fileName);
+}
+
+module.exports = {
+  uploadImageDataUrl,
+};


### PR DESCRIPTION
- Add file storage service with Cloudinary integration
- Keep fallback to local uploads directory for development
- Refactor avatar, establishments, reviews and default-config upload endpoints to use shared storage service
- Keep /uploads static serving for local/fallback mode
- Update Vercel deploy docs with required CLOUDINARY_* env vars and CORS/PGPOOL notes

This resolves images disappearing after upload on serverless deployments.