### PR TITLE
fix(web3): anchor reviews with backend hash and improve on-chain proof reliability

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1194,28 +1194,14 @@ function App() {
           message: "Confirm the transaction in your wallet to anchor this review on-chain.",
         }))
 
-        const payload = {
-          review_id: reviewId,
-          user_id: userId,
-          establishment_id: reviewForm.establishment_id,
-          timestamp: new Date().toISOString(),
-          price: Number(reviewForm.price),
+        const reviewHash = String(created?.review_hash || "")
+        if (!ethers.isHexString(reviewHash, 32)) {
+          throw new Error("Invalid review hash returned by backend.")
         }
-
-        const reviewHash = ethers.solidityPackedKeccak256(
-          ["string", "string", "string", "string", "string"],
-          [
-            String(payload.review_id),
-            String(payload.user_id),
-            String(payload.establishment_id),
-            String(payload.timestamp),
-            String(payload.price),
-          ]
-        )
 
         const establishmentHash = ethers.solidityPackedKeccak256(
           ["string"],
-          [String(payload.establishment_id)]
+          [String(reviewForm.establishment_id)]
         )
 
         const tx = await contract.anchorReview(walletAddress, reviewHash, establishmentHash)


### PR DESCRIPTION
- Use backend-generated review_hash for contract anchorReview calls
- Validate review_hash format before sending transaction
- Fix mismatch that caused "Pending anchor or event not found yet" in review details
- Improve chain proof fetch resilience with provider fallback and clearer RPC errors
- Show full explorer transaction URL in review details