### PR TITLE
Feature/frontend wallet auth

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -102,6 +102,22 @@
   margin-top: 12px;
 }
 
+.wallet-install-box {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  display: grid;
+  gap: 10px;
+}
+
+.wallet-install-links {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .wallet-button {
   border: 1px solid var(--border);
   background: var(--surface);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -160,6 +160,7 @@ function App() {
     if (!RPC_URL) return null
     return new ethers.JsonRpcProvider(RPC_URL)
   }, [])
+  const hasWalletProvider = useMemo(() => typeof window !== "undefined" && Boolean(window.ethereum), [])
   const explorerBaseUrl = useMemo(() => {
     const value = String(EXPLORER_TX_BASE_URL || "").trim()
     if (!value) return ""
@@ -1321,6 +1322,7 @@ function App() {
         walletUserName={walletUserName}
         isConnected={Boolean(walletAddress && token)}
         isAdmin={Boolean(walletAddress && token && isAdmin)}
+        hasWalletProvider={hasWalletProvider}
         onWalletAction={handleWalletAction}
         onNavigate={setActivePage}
       />
@@ -1333,35 +1335,47 @@ function App() {
               <>
                 <p>Select a wallet provider to continue.</p>
                 <div className="pill" style={{ marginBottom: "12px" }}>{detectProvider()}</div>
-                <div className="wallet-grid">
-                  <button className="wallet-button" onClick={connectWallet} disabled={walletBusy}>
-                    {walletBusy
-                      ? walletFlowStep === "network"
-                        ? "Switching network..."
-                        : walletFlowStep === "accounts"
-                          ? "Requesting account..."
-                          : "Waiting signature..."
-                      : "MetaMask"}
-                  </button>
-                  <button className="wallet-button" onClick={connectWallet} disabled={walletBusy}>
-                    {walletBusy
-                      ? walletFlowStep === "network"
-                        ? "Switching network..."
-                        : walletFlowStep === "accounts"
-                          ? "Requesting account..."
-                          : "Waiting signature..."
-                      : "PaliWallet"}
-                  </button>
-                  <button className="wallet-button" onClick={connectWallet} disabled={walletBusy}>
-                    {walletBusy
-                      ? walletFlowStep === "network"
-                        ? "Switching network..."
-                        : walletFlowStep === "accounts"
-                          ? "Requesting account..."
-                          : "Waiting signature..."
-                      : "Other Wallet"}
-                  </button>
-                </div>
+                {!hasWalletProvider ? (
+                  <div className="wallet-install-box">
+                    <p style={{ margin: 0 }}>
+                      No EVM wallet detected in this browser. You can still browse in read-only mode.
+                    </p>
+                    <div className="wallet-install-links">
+                      <a href="https://metamask.io/download/" target="_blank" rel="noreferrer">Install MetaMask</a>
+                      <a href="https://paliwallet.com/" target="_blank" rel="noreferrer">Install PaliWallet</a>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="wallet-grid">
+                    <button className="wallet-button" onClick={connectWallet} disabled={walletBusy}>
+                      {walletBusy
+                        ? walletFlowStep === "network"
+                          ? "Switching network..."
+                          : walletFlowStep === "accounts"
+                            ? "Requesting account..."
+                            : "Waiting signature..."
+                        : "MetaMask"}
+                    </button>
+                    <button className="wallet-button" onClick={connectWallet} disabled={walletBusy}>
+                      {walletBusy
+                        ? walletFlowStep === "network"
+                          ? "Switching network..."
+                          : walletFlowStep === "accounts"
+                            ? "Requesting account..."
+                            : "Waiting signature..."
+                        : "PaliWallet"}
+                    </button>
+                    <button className="wallet-button" onClick={connectWallet} disabled={walletBusy}>
+                      {walletBusy
+                        ? walletFlowStep === "network"
+                          ? "Switching network..."
+                          : walletFlowStep === "accounts"
+                            ? "Requesting account..."
+                            : "Waiting signature..."
+                        : "Other Wallet"}
+                    </button>
+                  </div>
+                )}
               </>
             ) : (
               <>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,4 +1,12 @@
-export default function Header({ walletAddress, walletUserName, isConnected, isAdmin, onWalletAction, onNavigate }) {
+export default function Header({
+  walletAddress,
+  walletUserName,
+  isConnected,
+  isAdmin,
+  hasWalletProvider,
+  onWalletAction,
+  onNavigate,
+}) {
   const shortAddress = walletAddress
     ? `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`
     : ""
@@ -27,11 +35,14 @@ export default function Header({ walletAddress, walletUserName, isConnected, isA
         </nav>
 
         <div className="topbar-actions">
+          {!hasWalletProvider && (
+            <span className="pill">Read-only mode</span>
+          )}
           <button className="lang-button">
             English ▾
           </button>
           <button className="primary-button" onClick={onWalletAction} title={walletAddress || "Connect wallet"}>
-            {isConnected ? `${connectedLabel} | Desconectar` : "Connect wallet"}
+            {isConnected ? `${connectedLabel} | Desconectar` : hasWalletProvider ? "Connect wallet" : "Install wallet"}
           </button>
         </div>
       </div>


### PR DESCRIPTION
- Detect wallet provider availability in frontend app state
- Show read-only badge in navbar when no wallet extension is installed
- Update wallet CTA label to "Install wallet" when provider is missing
- Improve connect modal:
  - show read-only guidance when no provider is detected
  - add direct install links for MetaMask and PaliWallet
  - hide unusable connect buttons without provider
- Add styles for wallet install helper panel