### PR TITLE
feat(reviews): persist and expose public tx hash for on-chain anchored reviews

### DIFF
--- a/migrations/011_create_review_anchors.sql
+++ b/migrations/011_create_review_anchors.sql
@@ -1,0 +1,14 @@
+-- Migration: persist public blockchain tx metadata for reviews
+
+CREATE TABLE review_anchors (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    review_id UUID NOT NULL UNIQUE REFERENCES reviews (id) ON DELETE RESTRICT,
+    tx_hash TEXT NOT NULL UNIQUE,
+    chain_id BIGINT,
+    block_number BIGINT,
+    block_timestamp TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT review_anchors_tx_hash_format CHECK (tx_hash ~* '^0x[0-9a-f]{64}$'),
+    CONSTRAINT review_anchors_chain_id_positive CHECK (chain_id IS NULL OR chain_id > 0),
+    CONSTRAINT review_anchors_block_number_non_negative CHECK (block_number IS NULL OR block_number >= 0)
+);

--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -1,11 +1,18 @@
 const express = require('express');
-const { createReview, getReviewById, listReviews, uploadReviewEvidenceImage } = require('../controllers/reviewsController');
+const {
+  createReview,
+  getReviewById,
+  listReviews,
+  uploadReviewEvidenceImage,
+  saveReviewAnchorTx,
+} = require('../controllers/reviewsController');
 const { authenticate } = require('../middlewares/auth');
 
 const reviewsRouter = express.Router();
 
 reviewsRouter.post('/', authenticate, createReview);
 reviewsRouter.post('/upload-evidence', authenticate, uploadReviewEvidenceImage);
+reviewsRouter.post('/:id/anchor-tx', authenticate, saveReviewAnchorTx);
 reviewsRouter.get('/', listReviews);
 reviewsRouter.get('/:id', getReviewById);
 


### PR DESCRIPTION
# Make blockchain transaction metadata publicly available from backend

## Summary

This PR ensures that blockchain transaction metadata is persistently stored in the backend, allowing Review details to display the `tx_hash` even when:

- No wallet is connected  
- No RPC access is available in the browser  

Transaction visibility no longer depends on live on-chain reads from the client.

---

## Problem

Previously, transaction information in Review details relied on live on-chain verification from the frontend.

If:
- The user had no wallet connected, or  
- The RPC endpoint was unavailable  

The UI could not display transaction information.

---

## Solution

Transaction metadata is now stored persistently in the backend after anchoring, and exposed through the Reviews API.

Live on-chain verification remains as a best-effort enrichment, but is no longer required to display transaction data.

---

## What Changed

### 1. Database

Added new table:

`review_anchors`  

Fields:
- `review_id`
- `tx_hash`
- `chain_id`
- `block_number`
- `block_timestamp`
- `created_at`

Migration added:
```
011_create_review_anchors.sql
```

---

### 2. Backend API

#### New endpoint

```
POST /reviews/:id/anchor-tx
```

**Access:** Authenticated (owner/admin only)

**Body:**
- `tx_hash` (required, 0x-prefixed 32-byte hash)
- `chain_id` (optional)
- `block_number` (optional)
- `block_timestamp` (optional, ISO datetime)

#### Extended review responses

The following endpoints now include transaction metadata:

- `GET /reviews`
- `GET /reviews/:id`

New fields in Review payload:
- `tx_hash`
- `chain_id`
- `block_number`
- `block_timestamp`
- `tx_recorded_at`

---

### 3. Frontend

#### Submission Flow Update

After `tx.wait()` resolves:
- Frontend sends transaction metadata to:
  ```
  POST /reviews/:id/anchor-tx
  ```

#### Review Details Rendering

If live on-chain verification is unavailable:
- UI displays backend-recorded `tx_hash`
- Explorer link is generated from stored data

---

## Behavior After This PR

- Users can see the transaction hash publicly in Review details, even in read-only mode.
- Transaction display no longer depends on wallet or RPC availability.
- Live verification remains optional and non-blocking.

---

## Validation

- Backend syntax checks passed (`node --check` on modified files)
- Frontend build passed (`npm run build`)

---

## Manual Test Plan

1. Run migration:
   ```
   011_create_review_anchors.sql
   ```
2. Create a review and anchor it on-chain.
3. Confirm frontend calls:
   ```
   POST /reviews/:id/anchor-tx
   ```
4. Open Review details with:
   - No wallet installed  
   - No wallet connected  
5. Verify:
   - `tx_hash` is visible
   - Explorer link opens the correct transaction

---

## Risk / Impact

**Impact level:** Low to Medium  
**Scope:** Review persistence and detail rendering  

Main risk:
- Migration not applied in the target environment.
