### PR TITLE
Release: Persist blockchain transaction metadata in backend

### DIFF
--- a/migrations/011_create_review_anchors.sql
+++ b/migrations/011_create_review_anchors.sql
@@ -1,0 +1,14 @@
+-- Migration: persist public blockchain tx metadata for reviews
+
+CREATE TABLE review_anchors (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    review_id UUID NOT NULL UNIQUE REFERENCES reviews (id) ON DELETE RESTRICT,
+    tx_hash TEXT NOT NULL UNIQUE,
+    chain_id BIGINT,
+    block_number BIGINT,
+    block_timestamp TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT review_anchors_tx_hash_format CHECK (tx_hash ~* '^0x[0-9a-f]{64}$'),
+    CONSTRAINT review_anchors_chain_id_positive CHECK (chain_id IS NULL OR chain_id > 0),
+    CONSTRAINT review_anchors_block_number_non_negative CHECK (block_number IS NULL OR block_number >= 0)
+);

--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -1,11 +1,18 @@
 const express = require('express');
-const { createReview, getReviewById, listReviews, uploadReviewEvidenceImage } = require('../controllers/reviewsController');
+const {
+  createReview,
+  getReviewById,
+  listReviews,
+  uploadReviewEvidenceImage,
+  saveReviewAnchorTx,
+} = require('../controllers/reviewsController');
 const { authenticate } = require('../middlewares/auth');
 
 const reviewsRouter = express.Router();
 
 reviewsRouter.post('/', authenticate, createReview);
 reviewsRouter.post('/upload-evidence', authenticate, uploadReviewEvidenceImage);
+reviewsRouter.post('/:id/anchor-tx', authenticate, saveReviewAnchorTx);
 reviewsRouter.get('/', listReviews);
 reviewsRouter.get('/:id', getReviewById);
 


### PR DESCRIPTION
# Release: Persist blockchain transaction metadata in backend

## Overview

This PR promotes the current `develop` branch into `main`.

Main feature included in this release:

- Persist blockchain transaction metadata (`tx_hash`, chain info, block info) in backend storage.
- Allow public visibility of transaction hash in Review details without requiring:
  - Wallet connection
  - Live RPC access

---

## Included Changes

### Backend
- Added `review_anchors` table
- Added `POST /reviews/:id/anchor-tx`
- Extended `GET /reviews` and `GET /reviews/:id` responses
- Added migration: `011_create_review_anchors.sql`

### Frontend
- Submission flow updated to store tx metadata after `tx.wait()`
- Review details now display backend-recorded transaction data
- Explorer link works in read-only mode

---

## Behavior in Production

- Users can see transaction hash publicly.
- Transaction visibility no longer depends on wallet or RPC availability.
- Live on-chain verification remains optional enrichment.

---

## Migration Required

⚠️ Ensure the following migration is executed before or during deployment:

```
011_create_review_anchors.sql
```

---

## Validation

- Backend syntax checks passed
- Frontend build passed
- Manual verification completed

---

## Risk Assessment

Low-to-medium risk.

Primary risk:
- Migration not applied before deployment.

