### PR TITLE
feat: agregar panel Top Establishments con ranking por reviews y promedio de estrellas

### DIFF
--- a/controllers/establishmentsController.js
+++ b/controllers/establishmentsController.js
@@ -20,6 +20,26 @@ async function listEstablishments(req, res, next) {
   }
 }
 
+async function listTopReviewedEstablishments(req, res, next) {
+  try {
+    const page = Number(req.query.page || 1);
+    const pageSize = Number(req.query.page_size || 5);
+
+    if (!Number.isInteger(page) || page < 1) {
+      throw new ApiError(400, 'page must be a positive integer');
+    }
+
+    if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) {
+      throw new ApiError(400, 'page_size must be an integer between 1 and 100');
+    }
+
+    const result = await establishmentService.listTopReviewedEstablishments({ page, pageSize });
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
 async function createEstablishment(req, res, next) {
   try {
     const { name, category, image_url } = req.body || {};
@@ -118,4 +138,10 @@ async function uploadEstablishmentImage(req, res, next) {
   }
 }
 
-module.exports = { listEstablishments, createEstablishment, updateEstablishment, uploadEstablishmentImage };
+module.exports = {
+  listEstablishments,
+  listTopReviewedEstablishments,
+  createEstablishment,
+  updateEstablishment,
+  uploadEstablishmentImage,
+};

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -498,6 +498,11 @@
   top: 24px;
 }
 
+.sidebar-panels {
+  display: grid;
+  gap: 16px;
+}
+
 .modal-overlay {
   position: fixed;
   inset: 0;

--- a/repositories/establishmentRepository.js
+++ b/repositories/establishmentRepository.js
@@ -5,6 +5,38 @@ async function listEstablishments() {
   return result.rows;
 }
 
+async function listTopReviewedEstablishments({ limit, offset }) {
+  const dataResult = await query(
+    `SELECT
+      e.id,
+      e.name,
+      e.category,
+      e.image_url,
+      COUNT(r.id)::int AS review_count,
+      ROUND(AVG(r.stars)::numeric, 2)::float8 AS avg_stars
+     FROM establishments e
+     JOIN reviews r ON r.establishment_id = e.id
+     GROUP BY e.id
+     ORDER BY review_count DESC, avg_stars DESC, e.created_at DESC
+     LIMIT $1 OFFSET $2`,
+    [limit, offset]
+  );
+
+  const countResult = await query(
+    `SELECT COUNT(*)::int AS total
+     FROM (
+       SELECT r.establishment_id
+       FROM reviews r
+       GROUP BY r.establishment_id
+     ) grouped_reviews`
+  );
+
+  return {
+    rows: dataResult.rows,
+    total: countResult.rows[0]?.total || 0,
+  };
+}
+
 async function createEstablishment({ id, name, category, image_url }) {
   const result = await query(
     `INSERT INTO establishments (id, name, category, image_url)
@@ -35,6 +67,7 @@ async function updateEstablishment({ id, name, category, image_url }) {
 
 module.exports = {
   listEstablishments,
+  listTopReviewedEstablishments,
   createEstablishment,
   findById,
   updateEstablishment,

--- a/routes/establishments.js
+++ b/routes/establishments.js
@@ -1,10 +1,17 @@
 const express = require('express');
-const { listEstablishments, createEstablishment, updateEstablishment, uploadEstablishmentImage } = require('../controllers/establishmentsController');
+const {
+  listEstablishments,
+  listTopReviewedEstablishments,
+  createEstablishment,
+  updateEstablishment,
+  uploadEstablishmentImage,
+} = require('../controllers/establishmentsController');
 const { authenticate, authorizeAdmin } = require('../middlewares/auth');
 
 const establishmentsRouter = express.Router();
 
 establishmentsRouter.get('/', listEstablishments);
+establishmentsRouter.get('/top-reviewed', listTopReviewedEstablishments);
 establishmentsRouter.post('/upload-image', authenticate, authorizeAdmin, uploadEstablishmentImage);
 establishmentsRouter.post('/', authenticate, authorizeAdmin, createEstablishment);
 establishmentsRouter.put('/:id', authenticate, authorizeAdmin, updateEstablishment);

--- a/services/establishmentService.js
+++ b/services/establishmentService.js
@@ -1,5 +1,11 @@
 const crypto = require('crypto');
-const { listEstablishments, createEstablishment, findById, updateEstablishment } = require('../repositories/establishmentRepository');
+const {
+  listEstablishments,
+  listTopReviewedEstablishments,
+  createEstablishment,
+  findById,
+  updateEstablishment,
+} = require('../repositories/establishmentRepository');
 
 async function listEstablishmentsService() {
   return listEstablishments();
@@ -8,6 +14,24 @@ async function listEstablishmentsService() {
 async function createEstablishmentService({ name, category, image_url }) {
   const id = crypto.randomUUID();
   return createEstablishment({ id, name, category, image_url });
+}
+
+async function listTopReviewedEstablishmentsService({ page, pageSize }) {
+  const offset = (page - 1) * pageSize;
+  const { rows, total } = await listTopReviewedEstablishments({ limit: pageSize, offset });
+
+  return {
+    data: rows.map((row) => ({
+      ...row,
+      review_count: Number(row.review_count || 0),
+      avg_stars: Number(row.avg_stars || 0),
+    })),
+    meta: {
+      page,
+      page_size: pageSize,
+      total,
+    },
+  };
 }
 
 async function getEstablishmentById(id) {
@@ -21,6 +45,7 @@ async function updateEstablishmentService({ id, name, category, image_url }) {
 module.exports = {
   establishmentService: {
     listEstablishments: listEstablishmentsService,
+    listTopReviewedEstablishments: listTopReviewedEstablishmentsService,
     createEstablishment: createEstablishmentService,
     getEstablishmentById,
     updateEstablishment: updateEstablishmentService,


### PR DESCRIPTION
# Add Top Establishments section with backend support

## Summary

This PR introduces a new **Top Establishments** section, separated from the user leaderboard.

The new section displays:

- Ranking of establishments with the highest number of reviews
- Total review count per establishment
- Average star rating
- Establishment image next to the name (with initial fallback if no image)

Backend support is added to fetch this ranking in a paginated way.

---

## Main Changes

### Backend

- New endpoint:
  ```
  GET /establishments/top-reviewed
  ```
- Aggregated query to compute:
  - `review_count`
  - `avg_stars`
- Pagination support for the ranking response

---

### Frontend

- Integration to consume `GET /establishments/top-reviewed`
- New independent UI card/section separated from the user leaderboard
- Render establishment image in each row (fallback to name initial if no image)

---

## Result

- Clear separation between user leaderboard and establishment ranking
- Better visibility of most-reviewed establishments
- Improved UI with visual identification via establishment images
- Scalable backend endpoint ready for pagination
