### PR TITLE
fix: provider selection (MetaMask vs Pali) + wallet logo branding in login modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const { authRouter } = require('./routes/auth');
 const { swaggerSpec } = require('./config/swagger');
 const { adminRouter } = require('./routes/admin');
 const { healthRouter } = require('./routes/health');
+const { configRouter } = require('./routes/config');
 const { getUploadsBaseDir } = require('./utils/uploadStorage');
 const cors = require('cors');
 
@@ -57,6 +58,7 @@ app.get('/', (req, res) => {
 });
 
 app.use('/auth', authRouter);
+app.use('/config', configRouter);
 
 app.use('/users', usersRouter);
 app.use('/establishments', establishmentsRouter);

--- a/config/swagger.js
+++ b/config/swagger.js
@@ -708,7 +708,11 @@ swaggerSpec.paths = {
                     stars_points_yes: 1,
                     stars_points_no: 0,
                     price_points_lt_100: 1,
-                    price_points_gte_100: 2
+                    price_points_gte_100: 2,
+                    default_user_avatar_url: 'https://example.com/avatar.png',
+                    metamask_wallet_logo_url: 'https://example.com/metamask.png',
+                    pali_wallet_logo_url: 'https://example.com/pali.png',
+                    other_wallet_logo_url: 'https://example.com/other.png',
                   }
                 }
               }
@@ -742,7 +746,11 @@ swaggerSpec.paths = {
                   stars_points_yes: 1,
                   stars_points_no: 0,
                   price_points_lt_100: 1,
-                  price_points_gte_100: 2
+                  price_points_gte_100: 2,
+                  default_user_avatar_url: 'https://example.com/avatar.png',
+                  metamask_wallet_logo_url: 'https://example.com/metamask.png',
+                  pali_wallet_logo_url: 'https://example.com/pali.png',
+                  other_wallet_logo_url: 'https://example.com/other.png',
                 }
               }
             }
@@ -765,6 +773,44 @@ swaggerSpec.paths = {
         }
       }
     }
+  },
+  '/admin/points-config/wallet-logo': {
+    post: {
+      summary: 'Upload wallet logo (metamask, pali, other)',
+      security: [{ BearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            examples: {
+              uploadLogo: {
+                value: {
+                  wallet_key: 'metamask',
+                  file_name: 'metamask-logo.png',
+                  mime_type: 'image/png',
+                  data_url: 'data:image/png;base64,...',
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        201: { description: 'Created' },
+        400: {
+          description: 'Validation error',
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } },
+        },
+        401: {
+          description: 'Unauthorized',
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } },
+        },
+        403: {
+          description: 'Forbidden',
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } },
+        },
+      },
+    },
   },
   '/syscoin/review-hash': {
     post: {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,8 @@ import "./App.css"
 const DEFAULT_PAGE_SIZE = 6
 const MAX_ESTABLISHMENT_IMAGE_INPUT_BYTES = 2_000_000
 const ESTABLISHMENT_IMAGE_MAX_DIMENSION = 960
+const MAX_WALLET_LOGO_INPUT_BYTES = 1_000_000
+const WALLET_LOGO_STANDARD_SIZE = 256
 const MAX_REVIEW_EVIDENCE_IMAGES = 3
 const MIN_REVIEW_EVIDENCE_IMAGES = 1
 const MAX_REVIEW_TITLE_WORDS = 12
@@ -35,26 +37,21 @@ const ESTABLISHMENT_CATEGORIES = [
   "Services",
 ]
 const REVIEW_SUCCESS_MESSAGE = "Review submitted and anchored on-chain."
+const DEFAULT_METAMASK_LOGO = "https://cdn.jsdelivr.net/gh/MetaMask/brand-resources@master/SVG/metamask-fox.svg"
+const DEFAULT_PALI_LOGO = "https://www.paliwallet.com/images/logo/logo-white.svg"
 const WALLET_OPTION_CONFIG = {
   metamask: {
     key: "metamask",
     label: "MetaMask",
     description: "Browser extension",
-    icon: "https://cdn.jsdelivr.net/gh/MetaMask/brand-resources@master/SVG/metamask-fox.svg",
+    icon: DEFAULT_METAMASK_LOGO,
     installUrl: "https://metamask.io/download/",
-  },
-  walletconnect: {
-    key: "walletconnect",
-    label: "WalletConnect",
-    description: "Scan with mobile wallet",
-    icon: "https://avatars.githubusercontent.com/u/37784886?s=200&v=4",
-    installUrl: "",
   },
   pali: {
     key: "pali",
     label: "PaliWallet",
     description: "Browser extension",
-    icon: "https://www.paliwallet.com/images/logo/logo-white.svg",
+    icon: DEFAULT_PALI_LOGO,
     installUrl: "https://www.paliwallet.com/",
   },
   other: {
@@ -98,33 +95,54 @@ const getInjectedProviders = () => {
   return Array.from(new Set(candidates))
 }
 
-const isPaliProvider = (provider) => {
-  if (!provider) return false
-  const providerName = String(provider?.name || provider?.providerInfo?.name || provider?.providerInfo?.rdns || "").toLowerCase()
-  return Boolean(provider?.isPaliWallet || provider?.isPali || providerName.includes("pali"))
+const providerIdentityText = (provider) =>
+  String(
+    provider?.name ||
+    provider?.providerInfo?.name ||
+    provider?.providerInfo?.rdns ||
+    provider?.providerInfo?.uuid ||
+    ""
+  ).toLowerCase()
+
+const detectProviderType = (provider) => {
+  if (!provider) return "other"
+  const identity = providerIdentityText(provider)
+  if (
+    provider?.isPaliWallet ||
+    provider?.isPali ||
+    identity.includes("pali")
+  ) {
+    return "pali"
+  }
+  if (
+    provider?.isMetaMask &&
+    !provider?.isCoinbaseWallet &&
+    !provider?.isRabby &&
+    !provider?.isBraveWallet &&
+    !identity.includes("pali")
+  ) {
+    return "metamask"
+  }
+  return "other"
 }
 
-const isMetaMaskProvider = (provider) => Boolean(provider?.isMetaMask) && !isPaliProvider(provider)
+const isPaliProvider = (provider) => detectProviderType(provider) === "pali"
+const isMetaMaskProvider = (provider) => detectProviderType(provider) === "metamask"
 
 const resolveWalletProvider = (walletType) => {
   const providers = getInjectedProviders()
   if (!providers.length) return null
 
   if (walletType === "metamask") {
-    return providers.find((provider) => isMetaMaskProvider(provider)) || null
+    return providers.find((provider) => detectProviderType(provider) === "metamask") || null
   }
 
   if (walletType === "pali") {
-    return providers.find((provider) => isPaliProvider(provider)) || null
-  }
-
-  if (walletType === "walletconnect") {
-    // WalletConnect is not available via injected provider-only flow.
-    return null
+    return providers.find((provider) => detectProviderType(provider) === "pali") || null
   }
 
   if (walletType === "other") {
-    return providers.find((provider) => !isMetaMaskProvider(provider) && !isPaliProvider(provider)) || null
+    return providers.find((provider) => detectProviderType(provider) === "other") || null
   }
 
   return null
@@ -396,9 +414,13 @@ function App() {
     price_points_lt_100: 0,
     price_points_gte_100: 0,
     default_user_avatar_url: "",
+    metamask_wallet_logo_url: "",
+    pali_wallet_logo_url: "",
+    other_wallet_logo_url: "",
   })
   const [loadingPointsConfig, setLoadingPointsConfig] = useState(false)
   const [uploadingDefaultAvatar, setUploadingDefaultAvatar] = useState(false)
+  const [uploadingWalletLogoKey, setUploadingWalletLogoKey] = useState("")
   const [newEstablishment, setNewEstablishment] = useState({
     name: "",
     category: "",
@@ -439,18 +461,17 @@ function App() {
   const walletOptions = [
     {
       ...WALLET_OPTION_CONFIG.metamask,
+      icon: pointsConfig.metamask_wallet_logo_url || DEFAULT_METAMASK_LOGO,
       available: Boolean(resolveWalletProvider("metamask")),
     },
     {
-      ...WALLET_OPTION_CONFIG.walletconnect,
-      available: false,
-    },
-    {
       ...WALLET_OPTION_CONFIG.pali,
+      icon: pointsConfig.pali_wallet_logo_url || DEFAULT_PALI_LOGO,
       available: Boolean(resolveWalletProvider("pali")),
     },
     {
       ...WALLET_OPTION_CONFIG.other,
+      icon: pointsConfig.other_wallet_logo_url || "",
       available: Boolean(resolveWalletProvider("other")),
     },
   ]
@@ -567,6 +588,7 @@ function App() {
     fetchLeaderboard(1)
     fetchTopEstablishments(1)
     fetchEstablishments()
+    fetchPublicWalletBranding()
   }, [])
 
   const authPayload = useMemo(() => parseTokenPayload(token), [token])
@@ -778,10 +800,6 @@ function App() {
     const selectedOption = WALLET_OPTION_CONFIG[walletType] || WALLET_OPTION_CONFIG.other
     const provider = resolveWalletProvider(walletType)
     if (!provider) {
-      if (walletType === "walletconnect") {
-        setWalletModalStatus("WalletConnect no está habilitado en esta versión. Usa una wallet inyectada.")
-        return
-      }
       if (selectedOption.installUrl) {
         if (typeof window !== "undefined") {
           window.open(selectedOption.installUrl, "_blank", "noopener,noreferrer")
@@ -792,6 +810,14 @@ function App() {
       } else {
         setWalletModalStatus("No compatible injected wallet found for this option.")
       }
+      return
+    }
+
+    const providerType = detectProviderType(provider)
+    if ((walletType === "metamask" || walletType === "pali") && providerType !== walletType) {
+      setWalletModalStatus(
+        `No se encontró un provider independiente para ${selectedOption.label}. Abre la dApp dentro del navegador de esa wallet o desactiva temporalmente otras extensiones EVM.`
+      )
       return
     }
 
@@ -1036,6 +1062,51 @@ function App() {
         dataUrl,
         mimeType: outputMime,
         fileName: file.name || "establishment",
+      }
+    } finally {
+      URL.revokeObjectURL(objectUrl)
+    }
+  }
+
+  const prepareWalletLogoImage = async (file) => {
+    const allowedMime = ["image/jpeg", "image/png", "image/webp"]
+    if (!allowedMime.includes(file.type)) {
+      throw new Error("Formato inválido para logo. Usa JPG, PNG o WEBP.")
+    }
+    if (file.size > MAX_WALLET_LOGO_INPUT_BYTES) {
+      throw new Error("El logo excede el tamaño máximo permitido (1MB).")
+    }
+
+    const objectUrl = URL.createObjectURL(file)
+    try {
+      const img = await new Promise((resolve, reject) => {
+        const image = new Image()
+        image.onload = () => resolve(image)
+        image.onerror = () => reject(new Error("No se pudo leer el logo seleccionado."))
+        image.src = objectUrl
+      })
+
+      const canvas = document.createElement("canvas")
+      canvas.width = WALLET_LOGO_STANDARD_SIZE
+      canvas.height = WALLET_LOGO_STANDARD_SIZE
+      const ctx = canvas.getContext("2d")
+      if (!ctx) throw new Error("No se pudo procesar el logo.")
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+      const scale = Math.min(canvas.width / img.width, canvas.height / img.height)
+      const targetWidth = Math.max(1, Math.round(img.width * scale))
+      const targetHeight = Math.max(1, Math.round(img.height * scale))
+      const offsetX = Math.round((canvas.width - targetWidth) / 2)
+      const offsetY = Math.round((canvas.height - targetHeight) / 2)
+      ctx.drawImage(img, offsetX, offsetY, targetWidth, targetHeight)
+
+      const outputMime = "image/png"
+      const dataUrl = canvas.toDataURL(outputMime, 0.92)
+      return {
+        dataUrl,
+        mimeType: outputMime,
+        fileName: file.name || "wallet-logo",
       }
     } finally {
       URL.revokeObjectURL(objectUrl)
@@ -1328,12 +1399,31 @@ function App() {
           price_points_lt_100: Number(config.price_points_lt_100 ?? 0),
           price_points_gte_100: Number(config.price_points_gte_100 ?? 0),
           default_user_avatar_url: config.default_user_avatar_url || "",
+          metamask_wallet_logo_url: config.metamask_wallet_logo_url || "",
+          pali_wallet_logo_url: config.pali_wallet_logo_url || "",
+          other_wallet_logo_url: config.other_wallet_logo_url || "",
         })
       }
     } catch (error) {
       setAdminStatus(error?.message || "No se pudo cargar la configuración de puntos.")
     } finally {
       setLoadingPointsConfig(false)
+    }
+  }
+
+  const fetchPublicWalletBranding = async () => {
+    try {
+      const config = await apiFetch("/config/points-config")
+      if (!config) return
+      setPointsConfig((prev) => ({
+        ...prev,
+        default_user_avatar_url: config.default_user_avatar_url || prev.default_user_avatar_url || "",
+        metamask_wallet_logo_url: config.metamask_wallet_logo_url || prev.metamask_wallet_logo_url || "",
+        pali_wallet_logo_url: config.pali_wallet_logo_url || prev.pali_wallet_logo_url || "",
+        other_wallet_logo_url: config.other_wallet_logo_url || prev.other_wallet_logo_url || "",
+      }))
+    } catch {
+      // Keep defaults if public config endpoint is unavailable.
     }
   }
 
@@ -1462,6 +1552,9 @@ function App() {
         price_points_lt_100: Number(pointsConfig.price_points_lt_100),
         price_points_gte_100: Number(pointsConfig.price_points_gte_100),
         default_user_avatar_url: pointsConfig.default_user_avatar_url || null,
+        metamask_wallet_logo_url: pointsConfig.metamask_wallet_logo_url || null,
+        pali_wallet_logo_url: pointsConfig.pali_wallet_logo_url || null,
+        other_wallet_logo_url: pointsConfig.other_wallet_logo_url || null,
       }
 
       const updated = await apiFetch("/admin/points-config", {
@@ -1478,6 +1571,9 @@ function App() {
         price_points_lt_100: Number(updated.price_points_lt_100 ?? 0),
         price_points_gte_100: Number(updated.price_points_gte_100 ?? 0),
         default_user_avatar_url: updated.default_user_avatar_url || "",
+        metamask_wallet_logo_url: updated.metamask_wallet_logo_url || "",
+        pali_wallet_logo_url: updated.pali_wallet_logo_url || "",
+        other_wallet_logo_url: updated.other_wallet_logo_url || "",
       })
       setAdminStatus("Configuración de puntos actualizada.")
     } catch (error) {
@@ -1508,6 +1604,38 @@ function App() {
       setAdminStatus(error?.message || "No se pudo subir el avatar por defecto.")
     } finally {
       setUploadingDefaultAvatar(false)
+    }
+  }
+
+  const uploadWalletLogo = async (walletKey, file) => {
+    if (!isAdmin) return
+    if (!walletKey || !file) return
+
+    setUploadingWalletLogoKey(walletKey)
+    setAdminStatus("")
+    try {
+      const prepared = await prepareWalletLogoImage(file)
+      const uploaded = await apiFetch("/admin/points-config/wallet-logo", {
+        method: "POST",
+        body: JSON.stringify({
+          wallet_key: walletKey,
+          file_name: prepared.fileName,
+          mime_type: prepared.mimeType,
+          data_url: prepared.dataUrl,
+        }),
+      })
+
+      setPointsConfig((prev) => ({
+        ...prev,
+        metamask_wallet_logo_url: uploaded.metamask_wallet_logo_url || prev.metamask_wallet_logo_url || "",
+        pali_wallet_logo_url: uploaded.pali_wallet_logo_url || prev.pali_wallet_logo_url || "",
+        other_wallet_logo_url: uploaded.other_wallet_logo_url || prev.other_wallet_logo_url || "",
+      }))
+      setAdminStatus("Logo de wallet actualizado correctamente.")
+    } catch (error) {
+      setAdminStatus(error?.message || "No se pudo subir el logo de wallet.")
+    } finally {
+      setUploadingWalletLogoKey("")
     }
   }
 
@@ -3843,6 +3971,52 @@ function App() {
                       style={{ width: "88px", height: "88px", objectFit: "cover", borderRadius: "50%", border: "1px solid #e5e7eb" }}
                     />
                   )}
+                  <label style={{ fontWeight: 600, marginTop: "10px" }}>Wallet logos</label>
+                  <FileUpload
+                    accept="image/jpeg,image/png,image/webp"
+                    onFile={(file) => uploadWalletLogo("metamask", file)}
+                    disabled={uploadingWalletLogoKey === "metamask"}
+                    buttonText="Subir logo MetaMask"
+                  />
+                  {uploadingWalletLogoKey === "metamask" && <p>Subiendo logo MetaMask...</p>}
+                  {pointsConfig.metamask_wallet_logo_url && (
+                    <img
+                      src={pointsConfig.metamask_wallet_logo_url}
+                      alt="MetaMask logo"
+                      style={{ width: "40px", height: "40px", objectFit: "contain", borderRadius: "8px", border: "1px solid #e5e7eb", background: "#fff" }}
+                    />
+                  )}
+                  <FileUpload
+                    accept="image/jpeg,image/png,image/webp"
+                    onFile={(file) => uploadWalletLogo("pali", file)}
+                    disabled={uploadingWalletLogoKey === "pali"}
+                    buttonText="Subir logo PaliWallet"
+                  />
+                  {uploadingWalletLogoKey === "pali" && <p>Subiendo logo PaliWallet...</p>}
+                  {pointsConfig.pali_wallet_logo_url && (
+                    <img
+                      src={pointsConfig.pali_wallet_logo_url}
+                      alt="PaliWallet logo"
+                      style={{ width: "40px", height: "40px", objectFit: "contain", borderRadius: "8px", border: "1px solid #e5e7eb", background: "#fff" }}
+                    />
+                  )}
+                  <FileUpload
+                    accept="image/jpeg,image/png,image/webp"
+                    onFile={(file) => uploadWalletLogo("other", file)}
+                    disabled={uploadingWalletLogoKey === "other"}
+                    buttonText="Subir logo Other Wallet"
+                  />
+                  {uploadingWalletLogoKey === "other" && <p>Subiendo logo Other Wallet...</p>}
+                  {pointsConfig.other_wallet_logo_url && (
+                    <img
+                      src={pointsConfig.other_wallet_logo_url}
+                      alt="Other wallet logo"
+                      style={{ width: "40px", height: "40px", objectFit: "contain", borderRadius: "8px", border: "1px solid #e5e7eb", background: "#fff" }}
+                    />
+                  )}
+                  <p style={{ margin: 0, color: "#6b7280", fontSize: "0.85rem" }}>
+                    Estándar recomendado: logo cuadrado {WALLET_LOGO_STANDARD_SIZE}x{WALLET_LOGO_STANDARD_SIZE}px, entrada máxima 1MB.
+                  </p>
                   <label style={{ fontWeight: 600, marginTop: "10px" }}>Configuración de puntos por review</label>
                   <input
                     className="input"

--- a/migrations/016_add_wallet_logo_urls_to_points_config.sql
+++ b/migrations/016_add_wallet_logo_urls_to_points_config.sql
@@ -1,0 +1,6 @@
+-- Migration: add configurable wallet logos to points configuration
+
+ALTER TABLE points_config
+ADD COLUMN IF NOT EXISTS metamask_wallet_logo_url TEXT,
+ADD COLUMN IF NOT EXISTS pali_wallet_logo_url TEXT,
+ADD COLUMN IF NOT EXISTS other_wallet_logo_url TEXT;

--- a/repositories/pointsConfigRepository.js
+++ b/repositories/pointsConfigRepository.js
@@ -9,7 +9,10 @@ async function getCurrentConfig(dbClient) {
       stars_points_no,
       price_points_lt_100,
       price_points_gte_100,
-      default_user_avatar_url
+      default_user_avatar_url,
+      metamask_wallet_logo_url,
+      pali_wallet_logo_url,
+      other_wallet_logo_url
      FROM points_config
      ORDER BY created_at DESC
      LIMIT 1`
@@ -29,8 +32,11 @@ async function updateConfig(dbClient, payload) {
       stars_points_no,
       price_points_lt_100,
       price_points_gte_100,
-      default_user_avatar_url
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+      default_user_avatar_url,
+      metamask_wallet_logo_url,
+      pali_wallet_logo_url,
+      other_wallet_logo_url
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
      RETURNING
       image_points_yes,
       image_points_no,
@@ -40,7 +46,10 @@ async function updateConfig(dbClient, payload) {
       stars_points_no,
       price_points_lt_100,
       price_points_gte_100,
-      default_user_avatar_url`,
+      default_user_avatar_url,
+      metamask_wallet_logo_url,
+      pali_wallet_logo_url,
+      other_wallet_logo_url`,
     [
       payload.image_points_yes,
       payload.image_points_no,
@@ -51,6 +60,9 @@ async function updateConfig(dbClient, payload) {
       payload.price_points_lt_100,
       payload.price_points_gte_100,
       payload.default_user_avatar_url || null,
+      payload.metamask_wallet_logo_url || null,
+      payload.pali_wallet_logo_url || null,
+      payload.other_wallet_logo_url || null,
     ]
   );
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getPointsConfig, updatePointsConfig, uploadDefaultAvatar } = require('../controllers/pointsConfigController');
+const { getPointsConfig, updatePointsConfig, uploadDefaultAvatar, uploadWalletLogo } = require('../controllers/pointsConfigController');
 const { authenticate, authorizeAdmin } = require('../middlewares/auth');
 
 const adminRouter = express.Router();
@@ -7,5 +7,6 @@ const adminRouter = express.Router();
 adminRouter.get('/points-config', authenticate, authorizeAdmin, getPointsConfig);
 adminRouter.put('/points-config', authenticate, authorizeAdmin, updatePointsConfig);
 adminRouter.post('/points-config/default-avatar', authenticate, authorizeAdmin, uploadDefaultAvatar);
+adminRouter.post('/points-config/wallet-logo', authenticate, authorizeAdmin, uploadWalletLogo);
 
 module.exports = { adminRouter };

--- a/routes/config.js
+++ b/routes/config.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { getPointsConfig } = require('../controllers/pointsConfigController');
+
+const configRouter = express.Router();
+
+// Public read-only branding/config endpoint.
+configRouter.get('/points-config', getPointsConfig);
+
+module.exports = { configRouter };

--- a/services/pointsConfigService.js
+++ b/services/pointsConfigService.js
@@ -20,6 +20,9 @@ async function setDefaultUserAvatar(defaultUserAvatarUrl) {
     stars_points_no: 0,
     price_points_lt_100: 0,
     price_points_gte_100: 0,
+    metamask_wallet_logo_url: null,
+    pali_wallet_logo_url: null,
+    other_wallet_logo_url: null,
   };
 
   return updateConfig(
@@ -34,6 +37,45 @@ async function setDefaultUserAvatar(defaultUserAvatarUrl) {
       price_points_lt_100: Number(base.price_points_lt_100 ?? 0),
       price_points_gte_100: Number(base.price_points_gte_100 ?? 0),
       default_user_avatar_url: defaultUserAvatarUrl,
+      metamask_wallet_logo_url: base.metamask_wallet_logo_url || null,
+      pali_wallet_logo_url: base.pali_wallet_logo_url || null,
+      other_wallet_logo_url: base.other_wallet_logo_url || null,
+    }
+  );
+}
+
+async function setWalletLogo(walletKey, walletLogoUrl) {
+  const current = await getCurrentConfig({ query });
+  const base = current || {
+    image_points_yes: 0,
+    image_points_no: 0,
+    description_points_gt_200: 0,
+    description_points_lte_200: 0,
+    stars_points_yes: 0,
+    stars_points_no: 0,
+    price_points_lt_100: 0,
+    price_points_gte_100: 0,
+    default_user_avatar_url: null,
+    metamask_wallet_logo_url: null,
+    pali_wallet_logo_url: null,
+    other_wallet_logo_url: null,
+  };
+
+  return updateConfig(
+    { query },
+    {
+      image_points_yes: Number(base.image_points_yes ?? 0),
+      image_points_no: Number(base.image_points_no ?? 0),
+      description_points_gt_200: Number(base.description_points_gt_200 ?? 0),
+      description_points_lte_200: Number(base.description_points_lte_200 ?? 0),
+      stars_points_yes: Number(base.stars_points_yes ?? 0),
+      stars_points_no: Number(base.stars_points_no ?? 0),
+      price_points_lt_100: Number(base.price_points_lt_100 ?? 0),
+      price_points_gte_100: Number(base.price_points_gte_100 ?? 0),
+      default_user_avatar_url: base.default_user_avatar_url || null,
+      metamask_wallet_logo_url: walletKey === 'metamask' ? walletLogoUrl : (base.metamask_wallet_logo_url || null),
+      pali_wallet_logo_url: walletKey === 'pali' ? walletLogoUrl : (base.pali_wallet_logo_url || null),
+      other_wallet_logo_url: walletKey === 'other' ? walletLogoUrl : (base.other_wallet_logo_url || null),
     }
   );
 }
@@ -43,5 +85,6 @@ module.exports = {
     getPointsConfig,
     setPointsConfig,
     setDefaultUserAvatar,
+    setWalletLogo,
   },
 };


### PR DESCRIPTION
## Title
fix: provider selection (MetaMask vs Pali) + wallet logo branding in login modal

## Description
- Corrige la selección de provider para evitar que al elegir MetaMask abra Pali (y viceversa), con validación de tipo antes de conectar.
- El login modal ahora usa branding configurable (MetaMask/Pali/Other) y carga logos desde config pública.
- Admin: se agregan uploads de logos de wallets con validación de tamaño/formato estándar.
