### PR TITLE
Fix wallet switching between MetaMask/Pali with EIP-6963 provider resolution

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -17,8 +17,9 @@ export default function Header({
   const [copied, setCopied] = useState(false)
   const walletRef = useRef(null)
 
-  const shortAddress = walletAddress
-    ? `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`
+  const visibleWalletAddress = isConnected ? walletAddress : ""
+  const shortAddress = visibleWalletAddress
+    ? `${visibleWalletAddress.slice(0, 6)}...${visibleWalletAddress.slice(-4)}`
     : ""
   const connectedLabel = walletProviderLabel || walletUserName || "Wallet"
   const navItems = useMemo(() => {
@@ -95,9 +96,9 @@ export default function Header({
   }
 
   const handleCopyAddress = async () => {
-    if (!walletAddress) return
+    if (!visibleWalletAddress) return
     try {
-      await navigator.clipboard.writeText(walletAddress)
+      await navigator.clipboard.writeText(visibleWalletAddress)
       setCopied(true)
       setTimeout(() => setCopied(false), 1400)
     } catch {
@@ -166,7 +167,7 @@ export default function Header({
               English ▾
             </button>
             <div className="wallet-menu-wrap" ref={walletRef}>
-              <button className="primary-button topbar-wallet-button" onClick={handleWalletClick} title={walletAddress || "Login"} aria-expanded={walletOpen}>
+              <button className="primary-button topbar-wallet-button" onClick={handleWalletClick} title={visibleWalletAddress || "Login"} aria-expanded={walletOpen}>
                 <span className="wallet-trigger-main">
                   <span className="wallet-trigger-label">{isConnected ? connectedLabel : "Login"}</span>
                   {isConnected ? <span className="wallet-trigger-address">{shortAddress}</span> : null}


### PR DESCRIPTION
### Summary
This PR fixes wallet switching issues when both MetaMask and PaliWallet are installed.

### What was happening
- The app could detect both wallets, but after disconnecting and reconnecting with the other option, it could still open/use the previous wallet provider.
- In some cases, the connected address looked stale after switching wallets.
- The Login button tooltip could still show the previously connected address after disconnect.

### What changed
- Added EIP-6963 provider discovery and in-memory registry.
- Prioritized wallet selection using EIP-6963 announced providers:
  - MetaMask selection prefers MetaMask-announced provider.
  - Pali selection prefers Pali/Pollum/Syscoin-announced provider.
- Kept robust legacy fallbacks for non-EIP-6963 environments (`window.ethereum` and known globals).
- Updated account/network/disconnect event subscriptions to follow the active selected provider instead of always using `window.ethereum`.
- Fixed Header wallet tooltip/copy behavior to only expose address when `isConnected` is true.

### Result
- Switching MetaMask <-> Pali after disconnect is now deterministic.
- Connected address reflects the currently selected wallet provider.
- No stale wallet address is shown on Login hover after disconnect.

### Validation
- Frontend build passes: `npm run build`
