### PR TITLE
fix(review-flow): persist reviews only after successful tx; reset on cancel; improve global status banner (#76)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -24,6 +24,46 @@
   padding: 32px 0 60px;
 }
 
+.status-banner-wrap {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 10px auto 0;
+  padding: 0 16px;
+}
+
+.status-banner {
+  width: fit-content;
+  max-width: min(720px, 100%);
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 10px 16px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 28px -20px rgba(15, 20, 26, 0.55);
+  opacity: 0;
+  transform: translateY(-6px) scale(0.98);
+  transition: opacity 0.24s ease, transform 0.24s ease;
+}
+
+.status-banner.show {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.status-banner.ok {
+  color: #065f46;
+  background: #ecfdf5;
+  border-color: #a7f3d0;
+}
+
+.status-banner.error {
+  color: #991b1b;
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+
 .hero {
   display: grid;
   gap: 18px;

--- a/frontend/src/components/WalletModal.jsx
+++ b/frontend/src/components/WalletModal.jsx
@@ -42,7 +42,7 @@ export default function WalletModal({
     document.body.style.overflow = "hidden"
 
     const onEscape = (event) => {
-      if (event.key === "Escape" && !walletBusy) onClose()
+      if (event.key === "Escape") onClose()
     }
 
     window.addEventListener("keydown", onEscape)
@@ -55,7 +55,7 @@ export default function WalletModal({
   if (!isOpen) return null
 
   return (
-    <div className={`wallet-modal-overlay ${isVisible ? "show" : ""}`} onClick={() => !walletBusy && onClose()} aria-hidden={!isVisible}>
+    <div className={`wallet-modal-overlay ${isVisible ? "show" : ""}`} onClick={onClose} aria-hidden={!isVisible}>
       <div
         className={`wallet-modal-card ${isVisible ? "show" : ""}`}
         role="dialog"
@@ -68,7 +68,7 @@ export default function WalletModal({
             <h3>Connect Wallet</h3>
             <p>Choose a wallet to continue</p>
           </div>
-          <button className="wallet-modal-close" onClick={onClose} disabled={walletBusy} aria-label="Close wallet modal">
+          <button className="wallet-modal-close" onClick={onClose} aria-label="Close wallet modal">
             ×
           </button>
         </div>


### PR DESCRIPTION
## Description
Related issue: #76

### What this PR fixes
- Prevents saving reviews when wallet payment is cancelled, rejected, omitted, or fails.
- Ensures review persistence only happens after on-chain transaction success.
- Resets the review form/wizard when payment is cancelled (including modal outside click while signing/pending).
- Moves status messages to a global banner below the navbar.
- Adds smooth show/hide animation for status messages and avoids rendering them inside the review form.

### Backend changes
- `POST /reviews` now requires and validates:
  - `review_id`
  - `review_hash`
  - `review_timestamp`
  - `tx_hash`
- Added on-chain verification before DB persistence:
  - Transaction receipt must exist and be `status === 1`
  - Target contract must match configured contract
  - `ReviewAnchored` event must match expected wallet, review hash, and establishment hash
- Persist `review`, `review_evidence`, and `review_anchor` in the same transactional flow.
- Removed fire-and-forget anchoring behavior from review creation path.

### Frontend changes
- Review submission flow changed to:
  1. Build deterministic `review_hash` client-side
  2. Send `anchorReview` tx
  3. Wait for successful receipt
  4. Persist review via API
- Cancel behavior hardened:
  - Clicking outside tx modal or pressing `Cancel` during `signing/pending` now cancels active submission.
  - Form and wizard reset to initial state.
  - `Submitting...` state is cleared immediately.
  - Late async completions are ignored if submission was cancelled.
- Status UX:
  - Global centered banner below navbar.
  - Auto-dismiss with smooth fade/slide animation.

### Result
- No more “pending anchor/event not found” reviews caused by cancelled/omitted payment.
- No partial saves.
- Cleaner and more consistent UX around wallet/payment errors and status feedback.
