### PR TITLE
release: merge develop into main with review tx-safety + cancel-reset UX fixes 

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -24,6 +24,46 @@
   padding: 32px 0 60px;
 }
 
+.status-banner-wrap {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 10px auto 0;
+  padding: 0 16px;
+}
+
+.status-banner {
+  width: fit-content;
+  max-width: min(720px, 100%);
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 10px 16px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 28px -20px rgba(15, 20, 26, 0.55);
+  opacity: 0;
+  transform: translateY(-6px) scale(0.98);
+  transition: opacity 0.24s ease, transform 0.24s ease;
+}
+
+.status-banner.show {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.status-banner.ok {
+  color: #065f46;
+  background: #ecfdf5;
+  border-color: #a7f3d0;
+}
+
+.status-banner.error {
+  color: #991b1b;
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+
 .hero {
   display: grid;
   gap: 18px;

--- a/frontend/src/components/WalletModal.jsx
+++ b/frontend/src/components/WalletModal.jsx
@@ -42,7 +42,7 @@ export default function WalletModal({
     document.body.style.overflow = "hidden"
 
     const onEscape = (event) => {
-      if (event.key === "Escape" && !walletBusy) onClose()
+      if (event.key === "Escape") onClose()
     }
 
     window.addEventListener("keydown", onEscape)
@@ -55,7 +55,7 @@ export default function WalletModal({
   if (!isOpen) return null
 
   return (
-    <div className={`wallet-modal-overlay ${isVisible ? "show" : ""}`} onClick={() => !walletBusy && onClose()} aria-hidden={!isVisible}>
+    <div className={`wallet-modal-overlay ${isVisible ? "show" : ""}`} onClick={onClose} aria-hidden={!isVisible}>
       <div
         className={`wallet-modal-card ${isVisible ? "show" : ""}`}
         role="dialog"
@@ -68,7 +68,7 @@ export default function WalletModal({
             <h3>Connect Wallet</h3>
             <p>Choose a wallet to continue</p>
           </div>
-          <button className="wallet-modal-close" onClick={onClose} disabled={walletBusy} aria-label="Close wallet modal">
+          <button className="wallet-modal-close" onClick={onClose} aria-label="Close wallet modal">
             ×
           </button>
         </div>


### PR DESCRIPTION
## Description
Closes #76

### Summary
This PR promotes `develop` into `main` and includes the complete fix for the review submission flow where cancelled/omitted wallet payments could still leave persisted reviews.

### Included in this release
- Save reviews **only** after successful on-chain transaction confirmation.
- Server-side verification of tx receipt + `ReviewAnchored` event before DB persistence.
- Atomic persistence of review + evidence + anchor metadata.
- Cancellation hardening:
  - Outside-click/Cancel during signing/pending behaves as full cancellation.
  - Review form resets to initial state.
  - `Submitting...` state is cleared correctly.
  - Late async callbacks are ignored after cancellation.
- Status UX improvements:
  - Central global status banner below navbar.
  - Smooth show/hide transitions.
  - Removal of duplicated status message inside review form.

### Why this closes the issue
Issue #76 is resolved because reviews are no longer stored unless payment tx is confirmed as `success`, and all cancel/omit flows now reset cleanly without partial saves. closes #76 
