### PR TITLE
release: leaderboard and ranking enhancements

### DIFF
--- a/controllers/reviewsController.js
+++ b/controllers/reviewsController.js
@@ -538,6 +538,7 @@ async function listReviews(req, res, next) {
     const page = Number(req.query.page || 1);
     const pageSize = Number(req.query.page_size || 20);
     const establishmentId = req.query.establishment_id || null;
+    const userId = req.query.user_id || null;
     const sort = req.query.sort || null;
 
     if (!Number.isInteger(page) || page < 1) {
@@ -552,6 +553,10 @@ async function listReviews(req, res, next) {
       throw new ApiError(400, 'establishment_id must be a UUID');
     }
 
+    if (userId && !isValidUuid(userId)) {
+      throw new ApiError(400, 'user_id must be a UUID');
+    }
+
     if (sort && sort !== 'stars_desc') {
       throw new ApiError(400, 'sort must be stars_desc');
     }
@@ -560,6 +565,7 @@ async function listReviews(req, res, next) {
       page,
       pageSize,
       establishmentId,
+      userId,
       sort,
     });
 

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -10,6 +10,7 @@ const ALLOWED_AVATAR_MIME = {
   'image/webp': 'webp',
 };
 const MAX_AVATAR_BYTES = 1_500_000;
+const MAX_USER_NICKNAME_CHARS = 10;
 
 async function createUser(req, res, next) {
   try {
@@ -21,6 +22,9 @@ async function createUser(req, res, next) {
 
     if (isNonEmptyString(email) && !isValidEmail(email)) {
       throw new ApiError(400, 'email is invalid');
+    }
+    if (isNonEmptyString(name) && name.trim().length > MAX_USER_NICKNAME_CHARS) {
+      throw new ApiError(400, `name must be at most ${MAX_USER_NICKNAME_CHARS} characters`);
     }
     if (avatar_url != null && avatar_url !== '' && !isValidUrl(avatar_url)) {
       throw new ApiError(400, 'avatar_url must be a valid URL when provided');
@@ -73,18 +77,32 @@ async function updateMe(req, res, next) {
       throw new ApiError(401, 'invalid token');
     }
 
-    const { name, email, avatar_url } = req.body || {};
+    const { name, email, avatar_url, leaderboard_display_mode } = req.body || {};
+    const normalizedLeaderboardDisplayMode = isNonEmptyString(leaderboard_display_mode)
+      ? leaderboard_display_mode.trim().toLowerCase()
+      : null;
     if (email && !isValidEmail(email)) {
       throw new ApiError(400, 'email is invalid');
     }
+    if (isNonEmptyString(name) && name.trim().length > MAX_USER_NICKNAME_CHARS) {
+      throw new ApiError(400, `name must be at most ${MAX_USER_NICKNAME_CHARS} characters`);
+    }
     if (avatar_url != null && avatar_url !== '' && !isValidUrl(avatar_url)) {
       throw new ApiError(400, 'avatar_url must be a valid URL when provided');
+    }
+    if (
+      normalizedLeaderboardDisplayMode != null &&
+      normalizedLeaderboardDisplayMode !== 'wallet' &&
+      normalizedLeaderboardDisplayMode !== 'name'
+    ) {
+      throw new ApiError(400, "leaderboard_display_mode must be 'wallet' or 'name'");
     }
 
     const updatedUser = await userService.updateUserProfile(userId, {
       name: isNonEmptyString(name) ? name.trim() : null,
       email: isNonEmptyString(email) ? email.trim() : null,
       avatar_url: isNonEmptyString(avatar_url) ? avatar_url.trim() : null,
+      leaderboard_display_mode: normalizedLeaderboardDisplayMode,
     });
 
     res.status(200).json(updatedUser);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -589,6 +589,251 @@
   border-bottom: none;
 }
 
+.leaderboard-item-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.leaderboard-item-main span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.leaderboard-user-button {
+  all: unset;
+  cursor: pointer;
+  display: block;
+  min-width: 0;
+}
+
+.leaderboard-avatar-wrap {
+  position: relative;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+}
+
+.leaderboard-avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid #e5e7eb;
+}
+
+.leaderboard-fallback-avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid #e5e7eb;
+  display: grid;
+  place-items: center;
+  background: var(--surface-alt);
+  color: var(--muted);
+  font-weight: 700;
+  font-size: 0.78rem;
+}
+
+.leaderboard-item-meta {
+  display: grid;
+  justify-items: end;
+  gap: 3px;
+}
+
+.leaderboard-stars {
+  font-size: 0.82rem;
+}
+
+.leaderboard-full-panel {
+  grid-column: 1 / -1;
+}
+
+.leaderboard-full-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-bottom: 12px;
+}
+
+.leaderboard-full-list {
+  display: grid;
+  gap: 10px;
+}
+
+.leaderboard-full-entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 14px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fff;
+}
+
+.leaderboard-full-user {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.leaderboard-full-user strong,
+.leaderboard-full-user span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.leaderboard-full-user span {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.leaderboard-full-metrics {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.leaderboard-metric {
+  min-width: 82px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  display: grid;
+  gap: 2px;
+  justify-items: center;
+}
+
+.leaderboard-metric strong {
+  font-size: 0.95rem;
+}
+
+.leaderboard-metric span {
+  font-size: 0.74rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.leaderboard-full-pagination {
+  margin-top: 14px;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.leaderboard-user-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fff;
+}
+
+.leaderboard-user-avatar-lg {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid #e5e7eb;
+}
+
+.leaderboard-user-header-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.leaderboard-user-header-main h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.leaderboard-user-header-main p {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.leaderboard-medal {
+  position: absolute;
+  top: -8px;
+  right: -7px;
+  width: 19px;
+  height: 19px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 8px;
+  font-weight: 800;
+  line-height: 1;
+  border: 1px solid rgba(17, 24, 39, 0.2);
+  box-shadow: 0 3px 7px rgba(17, 24, 39, 0.24);
+  z-index: 2;
+}
+
+.leaderboard-medal::before,
+.leaderboard-medal::after {
+  content: "";
+  position: absolute;
+  top: -6px;
+  width: 5px;
+  height: 8px;
+  border-radius: 2px;
+  z-index: -1;
+}
+
+.leaderboard-medal::before {
+  left: 3px;
+  transform: rotate(-11deg);
+}
+
+.leaderboard-medal::after {
+  right: 3px;
+  transform: rotate(11deg);
+}
+
+.leaderboard-medal.gold {
+  background: radial-gradient(circle at 35% 30%, #fff6d6 0%, #f6cf69 45%, #c58b1b 100%);
+  color: #6b3b00;
+}
+
+.leaderboard-medal.gold::before,
+.leaderboard-medal.gold::after {
+  background: linear-gradient(180deg, #ef4444 0%, #b91c1c 100%);
+}
+
+.leaderboard-medal.silver {
+  background: radial-gradient(circle at 35% 30%, #ffffff 0%, #d7dde5 45%, #8b95a1 100%);
+  color: #374151;
+}
+
+.leaderboard-medal.silver::before,
+.leaderboard-medal.silver::after {
+  background: linear-gradient(180deg, #60a5fa 0%, #2563eb 100%);
+}
+
+.leaderboard-medal.bronze {
+  background: radial-gradient(circle at 35% 30%, #ffe7d7 0%, #d39a63 45%, #8c4a1b 100%);
+  color: #4a2c1a;
+}
+
+.leaderboard-medal.bronze::before,
+.leaderboard-medal.bronze::after {
+  background: linear-gradient(180deg, #34d399 0%, #059669 100%);
+}
+
 .footer {
   padding: 30px 0 40px;
   color: var(--muted);
@@ -1131,6 +1376,20 @@
   .topbar-inner {
     grid-template-columns: auto 1fr auto;
     gap: 10px;
+  }
+
+  .leaderboard-full-entry {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .leaderboard-full-metrics {
+    justify-content: flex-end;
+  }
+
+  .leaderboard-user-header {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .menu-toggle {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,11 +4,16 @@ import { ethers } from "ethers"
 import Header from "./components/Header"
 import Footer from "./components/Footer"
 import FileUpload from "./components/FileUpload"
+import FullLeaderboardPage from "./components/FullLeaderboardPage"
+import HomeSidebarPanels from "./components/HomeSidebarPanels"
+import LeaderboardUserPage from "./components/LeaderboardUserPage"
 import WalletModal from "./components/WalletModal"
 import { API_BASE, ABI, CHAIN_ID, CONTRACT_ADDRESS, EXPLORER_TX_BASE_URL, RPC_URL } from "./config"
 import "./App.css"
 
 const DEFAULT_PAGE_SIZE = 6
+const FULL_LEADERBOARD_PAGE_SIZE = 20
+const USER_REVIEWS_PAGE_SIZE = 10
 const MAX_ESTABLISHMENT_IMAGE_INPUT_BYTES = 2_000_000
 const ESTABLISHMENT_IMAGE_MAX_DIMENSION = 960
 const MAX_WALLET_LOGO_INPUT_BYTES = 1_000_000
@@ -335,6 +340,13 @@ const truncateWithEllipsis = (value, maxChars) => {
   return `${text.slice(0, maxChars)}...`
 }
 
+const formatShortWalletAddress = (value) => {
+  const wallet = String(value || "").trim()
+  if (!wallet) return ""
+  if (wallet.length <= 10) return wallet
+  return `${wallet.slice(0, 4)}...${wallet.slice(-3)}`
+}
+
 const formatReviewPublishedDateLabel = (value) => {
   if (!value) return ""
   const parsed = new Date(value)
@@ -570,6 +582,7 @@ function App() {
     name: "",
     email: "",
     avatar_url: "",
+    leaderboard_display_mode: "wallet",
   })
 
   const [reviewForm, setReviewForm] = useState({
@@ -627,9 +640,16 @@ function App() {
   const [reviewsMeta, setReviewsMeta] = useState({ page: 1, page_size: DEFAULT_PAGE_SIZE, total: 0 })
   const [leaderboard, setLeaderboard] = useState([])
   const [leaderMeta, setLeaderMeta] = useState({ page: 1, page_size: 5, total: 0 })
+  const [fullLeaderboard, setFullLeaderboard] = useState([])
+  const [fullLeaderMeta, setFullLeaderMeta] = useState({ page: 1, page_size: FULL_LEADERBOARD_PAGE_SIZE, total: 0 })
+  const [selectedLeaderboardUser, setSelectedLeaderboardUser] = useState(null)
+  const [selectedUserReviews, setSelectedUserReviews] = useState([])
+  const [selectedUserReviewsMeta, setSelectedUserReviewsMeta] = useState({ page: 1, page_size: USER_REVIEWS_PAGE_SIZE, total: 0 })
   const [topEstablishments, setTopEstablishments] = useState([])
   const [loadingReviews, setLoadingReviews] = useState(false)
   const [loadingLeaderboard, setLoadingLeaderboard] = useState(false)
+  const [loadingFullLeaderboard, setLoadingFullLeaderboard] = useState(false)
+  const [loadingSelectedUserReviews, setLoadingSelectedUserReviews] = useState(false)
   const [loadingTopEstablishments, setLoadingTopEstablishments] = useState(false)
   const [establishments, setEstablishments] = useState([])
   const [reviewsView, setReviewsView] = useState("list")
@@ -1049,6 +1069,7 @@ function App() {
       name: user.name || "",
       email: user.email || "",
       avatar_url: user.avatar_url || "",
+      leaderboard_display_mode: user.leaderboard_display_mode === "name" ? "name" : "wallet",
     })
     if (user.name) {
       setWalletUserName(user.name)
@@ -1863,6 +1884,7 @@ function App() {
           name: profile.name || null,
           email: profile.email || null,
           avatar_url: profile.avatar_url || null,
+          leaderboard_display_mode: profile.leaderboard_display_mode || "wallet",
         }),
       })
       hydrateProfileFromUser(updatedUser)
@@ -2292,6 +2314,43 @@ function App() {
     } finally {
       setLoadingLeaderboard(false)
     }
+  }
+
+  const fetchFullLeaderboard = async (page = 1) => {
+    setLoadingFullLeaderboard(true)
+    try {
+      const result = await apiFetch(`/leaderboard?page=${page}&page_size=${FULL_LEADERBOARD_PAGE_SIZE}`)
+      setFullLeaderboard(result.data || [])
+      setFullLeaderMeta(result.meta || { page, page_size: FULL_LEADERBOARD_PAGE_SIZE, total: 0 })
+    } catch {
+      setFullLeaderboard([])
+    } finally {
+      setLoadingFullLeaderboard(false)
+    }
+  }
+
+  const fetchReviewsByUser = async (targetUserId, page = 1) => {
+    if (!targetUserId) {
+      setSelectedUserReviews([])
+      return
+    }
+    setLoadingSelectedUserReviews(true)
+    try {
+      const result = await apiFetch(`/reviews?user_id=${encodeURIComponent(targetUserId)}&page=${page}&page_size=${USER_REVIEWS_PAGE_SIZE}`)
+      setSelectedUserReviews(result.data || [])
+      setSelectedUserReviewsMeta(result.meta || { page, page_size: USER_REVIEWS_PAGE_SIZE, total: 0 })
+    } catch {
+      setSelectedUserReviews([])
+    } finally {
+      setLoadingSelectedUserReviews(false)
+    }
+  }
+
+  const openLeaderboardUser = (user) => {
+    if (!user?.user_id) return
+    setSelectedLeaderboardUser(user)
+    setActivePage("leaderboard-user")
+    fetchReviewsByUser(user.user_id, 1)
   }
 
   const fetchTopEstablishments = async (page = 1) => {
@@ -3315,6 +3374,11 @@ function App() {
     }
   }, [activePage, isAdmin])
 
+  useEffect(() => {
+    if (activePage !== "leaderboard") return
+    fetchFullLeaderboard(1)
+  }, [activePage])
+
   return (
     <div className="app-shell">
       <Header
@@ -3325,7 +3389,7 @@ function App() {
         isConnected={Boolean(walletAddress && token)}
         isAdmin={Boolean(walletAddress && token && isAdmin)}
         hasWalletProvider={hasWalletProvider}
-        activePage={activePage}
+        activePage={activePage === "leaderboard-user" ? "leaderboard" : activePage}
         onWalletAction={handleWalletAction}
         onNavigate={setActivePage}
       />
@@ -3664,92 +3728,47 @@ function App() {
                 )}
               </section>
 
-              <div className="sidebar-panels leaderboard-panel">
-                <aside className="panel">
-                  <div className="panel-header">
-                    <h3 className="panel-title">Leaderboard</h3>
-                    <span className="pill">Top</span>
-                  </div>
-                  {loadingLeaderboard ? (
-                    <p>Loading leaderboard...</p>
-                  ) : (
-                    leaderboard.map((entry, index) => (
-                      <div className="leaderboard-entry" key={entry.user_id || index}>
-                        <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
-                          <strong>#{index + 1}</strong>
-                          <img
-                            src={(entry.avatar_url || "").trim() || getDefaultAvatarUrl(entry.user_id || entry.name || index)}
-                            alt={entry.name || "User"}
-                            style={{ width: "34px", height: "34px", borderRadius: "50%", objectFit: "cover", border: "1px solid #e5e7eb" }}
-                          />
-                          <span>{entry.name || "Anon"}</span>
-                        </div>
-                        <div className="pill">{entry.total_points} pts</div>
-                      </div>
-                    ))
-                  )}
-                  <button className="ghost-button" style={{ marginTop: "16px" }}>
-                    View full ranking
-                  </button>
-                </aside>
-
-                <aside className="panel">
-                  <div className="panel-header">
-                    <h3 className="panel-title">Top Establishments</h3>
-                    <span className="pill">Reviews</span>
-                  </div>
-                  {loadingTopEstablishments ? (
-                    <p>Loading top establishments...</p>
-                  ) : topEstablishments.length === 0 ? (
-                    <p>No hay reviews suficientes todavía.</p>
-                  ) : (
-                    topEstablishments.map((entry, index) => {
-                      const stars = Math.round(Number(entry.avg_stars || 0))
-                      return (
-                        <div className="leaderboard-entry" key={entry.id || index}>
-                          <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
-                            <strong>#{index + 1}</strong>
-                            {(entry.image_url || "").trim() ? (
-                              <img
-                                src={(entry.image_url || "").trim()}
-                                alt={entry.name || "Establishment"}
-                                style={{ width: "34px", height: "34px", borderRadius: "50%", objectFit: "cover", border: "1px solid #e5e7eb" }}
-                              />
-                            ) : (
-                              <div
-                                style={{
-                                  width: "34px",
-                                  height: "34px",
-                                  borderRadius: "50%",
-                                  border: "1px solid #e5e7eb",
-                                  display: "grid",
-                                  placeItems: "center",
-                                  background: "var(--surface-alt)",
-                                  color: "var(--muted)",
-                                  fontWeight: 700,
-                                  fontSize: "0.78rem",
-                                }}
-                              >
-                                {(entry.name || "E")?.[0] || "E"}
-                              </div>
-                            )}
-                            <span>{entry.name || "Establishment"}</span>
-                          </div>
-                          <div style={{ display: "grid", justifyItems: "end", gap: "3px" }}>
-                            <div className="pill">{Number(entry.review_count || 0)} reviews</div>
-                            <div className="review-stars" style={{ fontSize: "0.82rem" }}>
-                              {"★".repeat(stars)}
-                              {"☆".repeat(5 - stars)} ({Number(entry.avg_stars || 0).toFixed(1)})
-                            </div>
-                          </div>
-                        </div>
-                      )
-                    })
-                  )}
-                </aside>
-              </div>
+              <HomeSidebarPanels
+                loadingLeaderboard={loadingLeaderboard}
+                leaderboard={leaderboard}
+                formatShortWalletAddress={formatShortWalletAddress}
+                getDefaultAvatarUrl={getDefaultAvatarUrl}
+                onViewFullRanking={() => {
+                  setActivePage("leaderboard")
+                  fetchFullLeaderboard(1)
+                }}
+                onSelectUser={openLeaderboardUser}
+                loadingTopEstablishments={loadingTopEstablishments}
+                topEstablishments={topEstablishments}
+              />
             </div>
           </>
+        )}
+
+        {activePage === "leaderboard" && (
+          <FullLeaderboardPage
+            loading={loadingFullLeaderboard}
+            entries={fullLeaderboard}
+            meta={fullLeaderMeta}
+            onPageChange={fetchFullLeaderboard}
+            onSelectUser={openLeaderboardUser}
+            formatShortWalletAddress={formatShortWalletAddress}
+            getDefaultAvatarUrl={getDefaultAvatarUrl}
+          />
+        )}
+
+        {activePage === "leaderboard-user" && selectedLeaderboardUser && (
+          <LeaderboardUserPage
+            user={selectedLeaderboardUser}
+            loadingReviews={loadingSelectedUserReviews}
+            reviews={selectedUserReviews}
+            reviewsMeta={selectedUserReviewsMeta}
+            onPageChange={(page) => fetchReviewsByUser(selectedLeaderboardUser.user_id, page)}
+            onBack={() => setActivePage("leaderboard")}
+            formatShortWalletAddress={formatShortWalletAddress}
+            getDefaultAvatarUrl={getDefaultAvatarUrl}
+            establishmentsById={establishmentsById}
+          />
         )}
 
         {activePage === "review" && (
@@ -4608,6 +4627,7 @@ function App() {
                   className="input"
                   placeholder="Name"
                   value={profile.name}
+                  maxLength={10}
                   onChange={(event) => setProfile({ ...profile, name: event.target.value })}
                 />
                 <FileUpload
@@ -4635,6 +4655,17 @@ function App() {
                   value={profile.email}
                   onChange={(event) => setProfile({ ...profile, email: event.target.value })}
                 />
+                <label style={{ fontSize: "12px", color: "var(--muted)" }}>
+                  Nombre público en leaderboard
+                </label>
+                <select
+                  className="input"
+                  value={profile.leaderboard_display_mode}
+                  onChange={(event) => setProfile({ ...profile, leaderboard_display_mode: event.target.value })}
+                >
+                  <option value="wallet">Wallet corta</option>
+                  <option value="name">Nombre</option>
+                </select>
               </div>
               <button className="primary-button" onClick={saveProfile} disabled={profileBusy}>
                 {profileBusy ? "Guardando..." : "Guardar cambios"}

--- a/frontend/src/components/FullLeaderboardPage.jsx
+++ b/frontend/src/components/FullLeaderboardPage.jsx
@@ -1,0 +1,86 @@
+import { resolveDisplayLabel } from "./leaderboardUtils"
+
+export default function FullLeaderboardPage({
+  loading,
+  entries,
+  meta,
+  onPageChange,
+  onSelectUser,
+  formatShortWalletAddress,
+  getDefaultAvatarUrl,
+}) {
+  const currentPage = Number(meta?.page || 1)
+  const pageSize = Number(meta?.page_size || 20)
+  const totalUsers = Number(meta?.total || 0)
+  const canGoPrev = currentPage > 1
+  const canGoNext = currentPage * pageSize < totalUsers
+  const firstPosition = totalUsers > 0 ? (currentPage - 1) * pageSize + 1 : 0
+  const lastPosition = totalUsers > 0 ? Math.min(currentPage * pageSize, totalUsers) : 0
+
+  return (
+    <div className="grid">
+      <section className="panel leaderboard-full-panel">
+        <div className="panel-header">
+          <h3 className="panel-title">Full Ranking</h3>
+          <span className="pill">{totalUsers} users</span>
+        </div>
+
+        <div className="leaderboard-full-meta">
+          <span>Showing {firstPosition}-{lastPosition}</span>
+          <span>Page {currentPage}</span>
+        </div>
+
+        {loading ? (
+          <p>Loading full ranking...</p>
+        ) : entries.length === 0 ? (
+          <p>No leaderboard data available yet.</p>
+        ) : (
+          <div className="leaderboard-full-list">
+            {entries.map((entry, index) => {
+              const shortWallet = formatShortWalletAddress(entry.wallet_address)
+              const displayLabel = resolveDisplayLabel(entry, shortWallet)
+              const globalRank = (currentPage - 1) * pageSize + index + 1
+              return (
+                <article className="leaderboard-full-entry" key={entry.user_id || globalRank}>
+                  <button className="leaderboard-user-button" onClick={() => onSelectUser?.(entry)} title="View user profile">
+                    <div className="leaderboard-item-main">
+                      <strong>#{globalRank}</strong>
+                      <img
+                        src={(entry.avatar_url || "").trim() || getDefaultAvatarUrl(entry.user_id || entry.wallet_address || globalRank)}
+                        alt={shortWallet || "User"}
+                        className="leaderboard-avatar"
+                      />
+                      <div className="leaderboard-full-user">
+                        <strong>{displayLabel}</strong>
+                        <span>{shortWallet || "No wallet"}</span>
+                      </div>
+                    </div>
+                  </button>
+                  <div className="leaderboard-full-metrics">
+                    <div className="leaderboard-metric">
+                      <strong>{Number(entry.total_points || 0)}</strong>
+                      <span>Points</span>
+                    </div>
+                    <div className="leaderboard-metric">
+                      <strong>{Number(entry.review_count || 0)}</strong>
+                      <span>Reviews</span>
+                    </div>
+                  </div>
+                </article>
+              )
+            })}
+          </div>
+        )}
+
+        <div className="leaderboard-full-pagination">
+          <button className="ghost-button" disabled={!canGoPrev || loading} onClick={() => onPageChange(currentPage - 1)}>
+            ← Prev
+          </button>
+          <button className="ghost-button" disabled={!canGoNext || loading} onClick={() => onPageChange(currentPage + 1)}>
+            Next →
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -24,6 +24,7 @@ export default function Header({
   const connectedLabel = walletProviderLabel || walletUserName || "Wallet"
   const navItems = useMemo(() => {
     const items = [
+      { key: "leaderboard", label: "Ranking" },
       { key: "review", label: "Review" },
     ]
 
@@ -134,6 +135,14 @@ export default function Header({
               {navItems.find((item) => item.key === "review").label}
             </button>
           )}
+          {navItems.find((item) => item.key === "leaderboard") && (
+            <button
+              className={`nav-link topbar-review-link ${activePage === "leaderboard" ? "active" : ""}`}
+              onClick={() => handleNavigate("leaderboard")}
+            >
+              {navItems.find((item) => item.key === "leaderboard").label}
+            </button>
+          )}
           <button className="lang-button topbar-lang-button">
             English ▾
           </button>
@@ -142,7 +151,7 @@ export default function Header({
         <div className={`topbar-menu ${menuOpen ? "open" : ""}`}>
           <nav className="topbar-nav">
             {navItems
-              .filter((item) => item.key !== "review")
+              .filter((item) => item.key !== "review" && item.key !== "leaderboard")
               .map((item) => (
                 <button
                   key={item.key}
@@ -162,6 +171,14 @@ export default function Header({
                 onClick={() => handleNavigate("review")}
               >
                 {navItems.find((item) => item.key === "review").label}
+              </button>
+            )}
+            {navItems.find((item) => item.key === "leaderboard") && (
+              <button
+                className={`nav-link topbar-review-link ${activePage === "leaderboard" ? "active" : ""}`}
+                onClick={() => handleNavigate("leaderboard")}
+              >
+                {navItems.find((item) => item.key === "leaderboard").label}
               </button>
             )}
             <button className="lang-button topbar-lang-button">

--- a/frontend/src/components/HomeSidebarPanels.jsx
+++ b/frontend/src/components/HomeSidebarPanels.jsx
@@ -1,0 +1,27 @@
+import LeaderboardPanel from "./LeaderboardPanel"
+import TopEstablishmentsPanel from "./TopEstablishmentsPanel"
+
+export default function HomeSidebarPanels({
+  loadingLeaderboard,
+  leaderboard,
+  formatShortWalletAddress,
+  getDefaultAvatarUrl,
+  onViewFullRanking,
+  onSelectUser,
+  loadingTopEstablishments,
+  topEstablishments,
+}) {
+  return (
+    <div className="sidebar-panels leaderboard-panel">
+      <LeaderboardPanel
+        loading={loadingLeaderboard}
+        entries={leaderboard}
+        formatShortWalletAddress={formatShortWalletAddress}
+        getDefaultAvatarUrl={getDefaultAvatarUrl}
+        onViewFullRanking={onViewFullRanking}
+        onSelectUser={onSelectUser}
+      />
+      <TopEstablishmentsPanel loading={loadingTopEstablishments} entries={topEstablishments} />
+    </div>
+  )
+}

--- a/frontend/src/components/LeaderboardPanel.jsx
+++ b/frontend/src/components/LeaderboardPanel.jsx
@@ -1,0 +1,56 @@
+import { getMedalClass, resolveDisplayLabel } from "./leaderboardUtils"
+
+export default function LeaderboardPanel({
+  loading,
+  entries,
+  formatShortWalletAddress,
+  getDefaultAvatarUrl,
+  onViewFullRanking,
+  onSelectUser,
+}) {
+  return (
+    <aside className="panel">
+      <div className="panel-header">
+        <h3 className="panel-title">Leaderboard</h3>
+        <span className="pill">Top</span>
+      </div>
+      {loading ? (
+        <p>Loading leaderboard...</p>
+      ) : (
+        entries.map((entry, index) => {
+          const shortWallet = formatShortWalletAddress(entry.wallet_address)
+          const displayLabel = resolveDisplayLabel(entry, shortWallet)
+          const medalClass = getMedalClass(index)
+          return (
+            <div className="leaderboard-entry" key={entry.user_id || index}>
+              <button className="leaderboard-user-button" onClick={() => onSelectUser?.(entry)} title="View user profile">
+                <div className="leaderboard-item-main">
+                  <strong>#{index + 1}</strong>
+                  <div className="leaderboard-avatar-wrap">
+                    <img
+                      src={(entry.avatar_url || "").trim() || getDefaultAvatarUrl(entry.user_id || entry.wallet_address || index)}
+                      alt={shortWallet || "User"}
+                      className="leaderboard-avatar"
+                    />
+                    {medalClass ? (
+                      <span className={`leaderboard-medal ${medalClass}`} aria-label={`Top ${index + 1}`}>
+                        {index + 1}
+                      </span>
+                    ) : null}
+                  </div>
+                  <span>{displayLabel}</span>
+                </div>
+              </button>
+              <div className="pill">{entry.total_points} pts</div>
+            </div>
+          )
+        })
+      )}
+      <div style={{ textAlign: "right", marginTop: "16px" }}>
+        <button className="ghost-button" onClick={onViewFullRanking}>
+          All
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/frontend/src/components/LeaderboardUserPage.jsx
+++ b/frontend/src/components/LeaderboardUserPage.jsx
@@ -1,0 +1,104 @@
+import { resolveDisplayLabel } from "./leaderboardUtils"
+
+export default function LeaderboardUserPage({
+  user,
+  loadingReviews,
+  reviews,
+  reviewsMeta,
+  onPageChange,
+  onBack,
+  formatShortWalletAddress,
+  getDefaultAvatarUrl,
+  establishmentsById,
+}) {
+  const shortWallet = formatShortWalletAddress(user?.wallet_address)
+  const displayLabel = resolveDisplayLabel(user, shortWallet)
+  const page = Number(reviewsMeta?.page || 1)
+  const pageSize = Number(reviewsMeta?.page_size || 10)
+  const total = Number(reviewsMeta?.total || 0)
+  const canGoPrev = page > 1
+  const canGoNext = page * pageSize < total
+
+  return (
+    <div className="grid">
+      <section className="panel leaderboard-full-panel">
+        <div className="panel-header">
+          <h3 className="panel-title">User Profile</h3>
+          <button className="ghost-button" onClick={onBack}>← Back to ranking</button>
+        </div>
+
+        <div className="leaderboard-user-header">
+          <img
+            src={(user?.avatar_url || "").trim() || getDefaultAvatarUrl(user?.user_id || user?.wallet_address || "user")}
+            alt={displayLabel || "User"}
+            className="leaderboard-user-avatar-lg"
+          />
+          <div className="leaderboard-user-header-main">
+            <h4>{displayLabel || "Anon"}</h4>
+            <p>{shortWallet || "No wallet"}</p>
+          </div>
+          <div className="leaderboard-full-metrics">
+            <div className="leaderboard-metric">
+              <strong>{Number(user?.total_points || 0)}</strong>
+              <span>Points</span>
+            </div>
+            <div className="leaderboard-metric">
+              <strong>{Number(user?.review_count || 0)}</strong>
+              <span>Reviews</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="panel-header" style={{ marginTop: "14px" }}>
+          <h3 className="panel-title">Reviews by user</h3>
+          <span className="pill">{total} total</span>
+        </div>
+
+        {loadingReviews ? (
+          <p>Loading user reviews...</p>
+        ) : reviews.length === 0 ? (
+          <p>This user has not published reviews yet.</p>
+        ) : (
+          <div className="leaderboard-full-list">
+            {reviews.map((review, index) => {
+              const globalPosition = (page - 1) * pageSize + index + 1
+              return (
+                <article key={review.id || globalPosition} className="leaderboard-full-entry">
+                  <div className="leaderboard-item-main">
+                    <strong>#{globalPosition}</strong>
+                    <div className="leaderboard-fallback-avatar">
+                      {(establishmentsById.get(review.establishment_id)?.name || "E")?.[0] || "E"}
+                    </div>
+                    <div className="leaderboard-full-user">
+                      <strong>{review.title || "Untitled review"}</strong>
+                      <span>{establishmentsById.get(review.establishment_id)?.name || review.establishment_id}</span>
+                    </div>
+                  </div>
+                  <div className="leaderboard-full-metrics">
+                    <div className="leaderboard-metric">
+                      <strong>{Number(review.points_awarded || 0)}</strong>
+                      <span>Points</span>
+                    </div>
+                    <div className="leaderboard-metric">
+                      <strong>{Number(review.stars || 0)}★</strong>
+                      <span>Stars</span>
+                    </div>
+                  </div>
+                </article>
+              )
+            })}
+          </div>
+        )}
+
+        <div className="leaderboard-full-pagination">
+          <button className="ghost-button" disabled={!canGoPrev || loadingReviews} onClick={() => onPageChange(page - 1)}>
+            ← Prev
+          </button>
+          <button className="ghost-button" disabled={!canGoNext || loadingReviews} onClick={() => onPageChange(page + 1)}>
+            Next →
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/components/TopEstablishmentsPanel.jsx
+++ b/frontend/src/components/TopEstablishmentsPanel.jsx
@@ -1,0 +1,45 @@
+export default function TopEstablishmentsPanel({ loading, entries }) {
+  return (
+    <aside className="panel">
+      <div className="panel-header">
+        <h3 className="panel-title">Top Establishments</h3>
+        <span className="pill">Reviews</span>
+      </div>
+      {loading ? (
+        <p>Loading top establishments...</p>
+      ) : entries.length === 0 ? (
+        <p>No hay reviews suficientes todavía.</p>
+      ) : (
+        entries.map((entry, index) => {
+          const stars = Math.round(Number(entry.avg_stars || 0))
+          return (
+            <div className="leaderboard-entry" key={entry.id || index}>
+              <div className="leaderboard-item-main">
+                <strong>#{index + 1}</strong>
+                {(entry.image_url || "").trim() ? (
+                  <img
+                    src={(entry.image_url || "").trim()}
+                    alt={entry.name || "Establishment"}
+                    className="leaderboard-avatar"
+                  />
+                ) : (
+                  <div className="leaderboard-fallback-avatar">
+                    {(entry.name || "E")?.[0] || "E"}
+                  </div>
+                )}
+                <span>{entry.name || "Establishment"}</span>
+              </div>
+              <div className="leaderboard-item-meta">
+                <div className="pill">{Number(entry.review_count || 0)} reviews</div>
+                <div className="review-stars leaderboard-stars">
+                  {"★".repeat(stars)}
+                  {"☆".repeat(5 - stars)} ({Number(entry.avg_stars || 0).toFixed(1)})
+                </div>
+              </div>
+            </div>
+          )
+        })
+      )}
+    </aside>
+  )
+}

--- a/frontend/src/components/leaderboardUtils.js
+++ b/frontend/src/components/leaderboardUtils.js
@@ -1,0 +1,14 @@
+export const getMedalClass = (index) => {
+  if (index === 0) return "gold"
+  if (index === 1) return "silver"
+  if (index === 2) return "bronze"
+  return ""
+}
+
+export const resolveDisplayLabel = (entry, shortWallet) => {
+  if (entry?.leaderboard_display_mode === "name") {
+    const nickname = String(entry?.name || "").trim().slice(0, 10)
+    return nickname || shortWallet || "Anon"
+  }
+  return shortWallet || "Anon"
+}

--- a/migrations/021_add_leaderboard_display_mode_to_users.sql
+++ b/migrations/021_add_leaderboard_display_mode_to_users.sql
@@ -1,0 +1,22 @@
+-- Migration: add user preference for leaderboard public identity
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS leaderboard_display_mode TEXT NOT NULL DEFAULT 'wallet';
+
+UPDATE users
+SET leaderboard_display_mode = 'wallet'
+WHERE leaderboard_display_mode IS NULL
+   OR leaderboard_display_mode NOT IN ('wallet', 'name');
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'users_leaderboard_display_mode_check'
+  ) THEN
+    ALTER TABLE users
+    ADD CONSTRAINT users_leaderboard_display_mode_check
+    CHECK (leaderboard_display_mode IN ('wallet', 'name'));
+  END IF;
+END $$;

--- a/repositories/leaderboardRepository.js
+++ b/repositories/leaderboardRepository.js
@@ -3,11 +3,14 @@ async function listLeaderboard(dbClient, { limit, offset }) {
     `SELECT
       u.id AS user_id,
       u.name,
+      u.wallet_address,
+      u.leaderboard_display_mode,
       COALESCE(
         NULLIF(BTRIM(u.avatar_url), ''),
         pc.default_user_avatar_url
       ) AS avatar_url,
-      COALESCE(SUM(r.points_awarded), 0)::int AS total_points
+      COALESCE(SUM(r.points_awarded), 0)::int AS total_points,
+      COALESCE(COUNT(r.id), 0)::int AS review_count
     FROM users u
     LEFT JOIN LATERAL (
       SELECT default_user_avatar_url

--- a/repositories/userRepository.js
+++ b/repositories/userRepository.js
@@ -23,12 +23,12 @@ async function findByWallet(walletAddress) {
   return legacyResult.rows[0] || null;
 }
 
-async function createUser({ id, wallet_address, email, name, avatar_url, role }) {
+async function createUser({ id, wallet_address, email, name, avatar_url, role, leaderboard_display_mode }) {
   const result = await query(
-    `INSERT INTO users (id, wallet_address, email, name, avatar_url, role)
-     VALUES ($1, $2, $3, $4, $5, $6)
-     RETURNING id, wallet_address, email, name, avatar_url, role, created_at`,
-    [id, wallet_address, email, name, avatar_url, role]
+    `INSERT INTO users (id, wallet_address, email, name, avatar_url, role, leaderboard_display_mode)
+     VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7, 'wallet'))
+     RETURNING id, wallet_address, email, name, avatar_url, role, leaderboard_display_mode, created_at`,
+    [id, wallet_address, email, name, avatar_url, role, leaderboard_display_mode || null]
   );
   return result.rows[0];
 }
@@ -78,28 +78,29 @@ async function findWalletRecord(address) {
 
 async function listUsers() {
   const result = await query(
-    'SELECT id, wallet_address, email, name, avatar_url, role, created_at FROM users ORDER BY created_at DESC'
+    'SELECT id, wallet_address, email, name, avatar_url, role, leaderboard_display_mode, created_at FROM users ORDER BY created_at DESC'
   );
   return result.rows;
 }
 
 async function findById(id) {
   const result = await query(
-    'SELECT id, wallet_address, email, name, avatar_url, role, created_at FROM users WHERE id = $1',
+    'SELECT id, wallet_address, email, name, avatar_url, role, leaderboard_display_mode, created_at FROM users WHERE id = $1',
     [id]
   );
   return result.rows[0] || null;
 }
 
-async function updateById(id, { name, email, avatar_url }) {
+async function updateById(id, { name, email, avatar_url, leaderboard_display_mode }) {
   const result = await query(
     `UPDATE users
      SET name = $2,
          email = $3,
-         avatar_url = $4
+         avatar_url = $4,
+         leaderboard_display_mode = COALESCE($5, leaderboard_display_mode)
      WHERE id = $1
-     RETURNING id, wallet_address, email, name, avatar_url, role, created_at`,
-    [id, name, email, avatar_url]
+     RETURNING id, wallet_address, email, name, avatar_url, role, leaderboard_display_mode, created_at`,
+    [id, name, email, avatar_url, leaderboard_display_mode || null]
   );
   return result.rows[0] || null;
 }

--- a/services/authService.js
+++ b/services/authService.js
@@ -88,7 +88,7 @@ async function resolveOrCreateUserByWallet(walletAddress) {
   let user = await findByWallet(normalizedAddress);
   if (!user) {
     const id = crypto.randomUUID();
-    const short = normalizedAddress.slice(2, 8);
+    const short = normalizedAddress.slice(2, 6);
     user = await createUser({
       id,
       wallet_address: normalizedAddress,

--- a/services/reviewService.js
+++ b/services/reviewService.js
@@ -268,12 +268,13 @@ async function getReviewByIdService(id) {
   return formatReviewResponse(review, review.evidence_images || []);
 }
 
-async function listReviewsService({ page, pageSize, establishmentId, sort }) {
+async function listReviewsService({ page, pageSize, establishmentId, userId, sort }) {
   const offset = (page - 1) * pageSize;
   const { rows, total } = await listReviewsRepo({ query }, {
     limit: pageSize,
     offset,
     establishmentId,
+    userId,
     sort,
   });
 


### PR DESCRIPTION
This release promotes leaderboard/ranking improvements from `develop` to `main`:

- Full ranking page with pagination.
- User profile page from ranking (header + user reviews).
- Leaderboard display rules:
  - short wallet format (`4...3`)
  - nickname max length (`10` chars).
- API updates:
  - leaderboard includes `review_count`
  - reviews endpoint supports `user_id` filter.
- Navbar adjustment: `Ranking` positioned on the right, after `Review`.
