### PR TITLE
feat(ui): add establishment detail page from top establishments with reviews list

### DIFF
--- a/frontend/src/components/EstablishmentDetailPage.jsx
+++ b/frontend/src/components/EstablishmentDetailPage.jsx
@@ -1,0 +1,131 @@
+const formatShortId = (value) => {
+  const text = String(value || "").trim()
+  if (!text) return "Unknown user"
+  if (text.length <= 12) return text
+  return `${text.slice(0, 8)}...${text.slice(-4)}`
+}
+
+const resolveAverageStars = (establishment, reviews) => {
+  const fromEstablishment = Number(establishment?.avg_stars)
+  if (Number.isFinite(fromEstablishment) && fromEstablishment > 0) {
+    return fromEstablishment.toFixed(1)
+  }
+  const list = Array.isArray(reviews) ? reviews : []
+  if (list.length === 0) return "0.0"
+  const total = list.reduce((sum, item) => sum + Number(item?.stars || 0), 0)
+  return (total / list.length).toFixed(1)
+}
+
+export default function EstablishmentDetailPage({
+  establishment,
+  reviews,
+  reviewsMeta,
+  loadingReviews,
+  onPageChange,
+  onBack,
+}) {
+  const currentPage = Number(reviewsMeta?.page || 1)
+  const pageSize = Number(reviewsMeta?.page_size || 10)
+  const total = Number(reviewsMeta?.total || 0)
+  const canGoPrev = currentPage > 1
+  const canGoNext = currentPage * pageSize < total
+  const averageStars = resolveAverageStars(establishment, reviews)
+  const reviewCount = Number(establishment?.review_count || total || 0)
+  const location = String(
+    establishment?.address || establishment?.district || establishment?.state_region || establishment?.country || ""
+  ).trim()
+  const category = String(establishment?.category || "").trim()
+
+  return (
+    <div className="grid">
+      <section className="panel leaderboard-full-panel">
+        <div className="panel-header">
+          <h3 className="panel-title">Establishment</h3>
+          <button className="ghost-button" onClick={onBack}>← Back</button>
+        </div>
+
+        <article className="leaderboard-full-entry" style={{ marginBottom: "12px" }}>
+          <div className="leaderboard-item-main">
+            {(establishment?.image_url || "").trim() ? (
+              <img
+                src={(establishment.image_url || "").trim()}
+                alt={establishment?.name || "Establishment"}
+                className="leaderboard-user-avatar-lg"
+              />
+            ) : (
+              <div className="leaderboard-fallback-avatar" style={{ width: "64px", height: "64px", fontSize: "1rem" }}>
+                {(establishment?.name || "E")?.[0] || "E"}
+              </div>
+            )}
+            <div className="leaderboard-full-user">
+              <strong>{establishment?.name || "Establishment"}</strong>
+              <span>{location || category || "No details"}</span>
+            </div>
+          </div>
+          <div className="leaderboard-full-metrics">
+            <div className="leaderboard-metric">
+              <strong>{averageStars}</strong>
+              <span>Avg Stars</span>
+            </div>
+            <div className="leaderboard-metric">
+              <strong>{reviewCount}</strong>
+              <span>Reviews</span>
+            </div>
+          </div>
+        </article>
+
+        <div className="leaderboard-full-meta">
+          <span>Reviews list</span>
+          <span>{total} total</span>
+        </div>
+
+        {loadingReviews ? (
+          <p>Loading reviews...</p>
+        ) : reviews.length === 0 ? (
+          <p>No reviews for this establishment yet.</p>
+        ) : (
+          <div className="leaderboard-full-list">
+            {reviews.map((review, index) => {
+              const stars = Number(review.stars || 0)
+              const createdAtLabel = review.created_at ? new Date(review.created_at).toLocaleString() : "N/A"
+              const rank = (currentPage - 1) * pageSize + index + 1
+              return (
+                <article className="leaderboard-full-entry" key={review.id || `${review.user_id}-${rank}`}>
+                  <div className="leaderboard-item-main">
+                    <strong>#{rank}</strong>
+                    <div className="leaderboard-fallback-avatar">
+                      {formatShortId(review.user_id).slice(0, 1)}
+                    </div>
+                    <div className="leaderboard-full-user">
+                      <strong className="review-title preview">{review.title || "Untitled review"}</strong>
+                      <span>{formatShortId(review.user_id)} · {createdAtLabel}</span>
+                      <span className="review-sub preview">{review.description || "No description"}</span>
+                    </div>
+                  </div>
+                  <div className="leaderboard-full-metrics">
+                    <div className="leaderboard-metric">
+                      <strong>
+                        {"★".repeat(stars)}
+                        {"☆".repeat(5 - stars)}
+                      </strong>
+                      <span>{stars}/5</span>
+                    </div>
+                  </div>
+                </article>
+              )
+            })}
+          </div>
+        )}
+
+        <div className="leaderboard-full-pagination">
+          <button className="ghost-button" disabled={!canGoPrev || loadingReviews} onClick={() => onPageChange(currentPage - 1)}>
+            ← Prev
+          </button>
+          <button className="ghost-button" disabled={!canGoNext || loadingReviews} onClick={() => onPageChange(currentPage + 1)}>
+            Next →
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/components/FullTopEstablishmentsPage.jsx
+++ b/frontend/src/components/FullTopEstablishmentsPage.jsx
@@ -1,0 +1,90 @@
+export default function FullTopEstablishmentsPage({
+  loading,
+  entries,
+  meta,
+  onPageChange,
+  onSelectEstablishment,
+}) {
+  const currentPage = Number(meta?.page || 1)
+  const pageSize = Number(meta?.page_size || 20)
+  const total = Number(meta?.total || 0)
+  const canGoPrev = currentPage > 1
+  const canGoNext = currentPage * pageSize < total
+  const firstPosition = total > 0 ? (currentPage - 1) * pageSize + 1 : 0
+  const lastPosition = total > 0 ? Math.min(currentPage * pageSize, total) : 0
+
+  return (
+    <div className="grid">
+      <section className="panel leaderboard-full-panel">
+        <div className="panel-header">
+          <h3 className="panel-title">Top Establishments</h3>
+          <span className="pill">{total} establishments</span>
+        </div>
+
+        <div className="leaderboard-full-meta">
+          <span>Showing {firstPosition}-{lastPosition}</span>
+          <span>Page {currentPage}</span>
+        </div>
+
+        {loading ? (
+          <p>Loading establishments...</p>
+        ) : entries.length === 0 ? (
+          <p>No establishments with reviews available yet.</p>
+        ) : (
+          <div className="leaderboard-full-list">
+            {entries.map((entry, index) => {
+              const globalRank = (currentPage - 1) * pageSize + index + 1
+              const avgStars = Number(entry.avg_stars || 0).toFixed(1)
+              const reviewCount = Number(entry.review_count || 0)
+              const category = String(entry.category || "").trim()
+              const location = String(entry.address || entry.district || entry.state_region || entry.country || "").trim()
+              return (
+                <article className="leaderboard-full-entry" key={entry.id || globalRank}>
+                  <button className="leaderboard-user-button" onClick={() => onSelectEstablishment?.(entry)} title="View establishment">
+                    <div className="leaderboard-item-main">
+                      <strong>#{globalRank}</strong>
+                      {(entry.image_url || "").trim() ? (
+                        <img
+                          src={(entry.image_url || "").trim()}
+                          alt={entry.name || "Establishment"}
+                          className="leaderboard-avatar"
+                        />
+                      ) : (
+                        <div className="leaderboard-fallback-avatar">
+                          {(entry.name || "E")?.[0] || "E"}
+                        </div>
+                      )}
+                      <div className="leaderboard-full-user">
+                        <strong>{entry.name || "Establishment"}</strong>
+                        <span>{location || category || "No details"}</span>
+                      </div>
+                    </div>
+                  </button>
+                  <div className="leaderboard-full-metrics">
+                    <div className="leaderboard-metric">
+                      <strong>{avgStars}</strong>
+                      <span>Avg Stars</span>
+                    </div>
+                    <div className="leaderboard-metric">
+                      <strong>{reviewCount}</strong>
+                      <span>Reviews</span>
+                    </div>
+                  </div>
+                </article>
+              )
+            })}
+          </div>
+        )}
+
+        <div className="leaderboard-full-pagination">
+          <button className="ghost-button" disabled={!canGoPrev || loading} onClick={() => onPageChange(currentPage - 1)}>
+            ← Prev
+          </button>
+          <button className="ghost-button" disabled={!canGoNext || loading} onClick={() => onPageChange(currentPage + 1)}>
+            Next →
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/components/HomeSidebarPanels.jsx
+++ b/frontend/src/components/HomeSidebarPanels.jsx
@@ -10,6 +10,8 @@ export default function HomeSidebarPanels({
   onSelectUser,
   loadingTopEstablishments,
   topEstablishments,
+  onViewAllTopEstablishments,
+  onSelectEstablishment,
 }) {
   return (
     <div className="sidebar-panels leaderboard-panel">
@@ -21,7 +23,12 @@ export default function HomeSidebarPanels({
         onViewFullRanking={onViewFullRanking}
         onSelectUser={onSelectUser}
       />
-      <TopEstablishmentsPanel loading={loadingTopEstablishments} entries={topEstablishments} />
+      <TopEstablishmentsPanel
+        loading={loadingTopEstablishments}
+        entries={topEstablishments}
+        onViewAll={onViewAllTopEstablishments}
+        onSelectEstablishment={onSelectEstablishment}
+      />
     </div>
   )
 }

--- a/frontend/src/components/TopEstablishmentsPanel.jsx
+++ b/frontend/src/components/TopEstablishmentsPanel.jsx
@@ -1,9 +1,13 @@
-export default function TopEstablishmentsPanel({ loading, entries }) {
+import { getMedalClass } from "./leaderboardUtils"
+
+const truncateName = (value, max = 10) => String(value || "Establishment").trim().slice(0, max) || "Establishment"
+
+export default function TopEstablishmentsPanel({ loading, entries, onViewAll, onSelectEstablishment }) {
   return (
     <aside className="panel">
       <div className="panel-header">
         <h3 className="panel-title">Top Establishments</h3>
-        <span className="pill">Reviews</span>
+        <span className="pill">Top</span>
       </div>
       {loading ? (
         <p>Loading top establishments...</p>
@@ -11,35 +15,51 @@ export default function TopEstablishmentsPanel({ loading, entries }) {
         <p>No hay reviews suficientes todavía.</p>
       ) : (
         entries.map((entry, index) => {
-          const stars = Math.round(Number(entry.avg_stars || 0))
+          const medalClass = getMedalClass(index)
+          const shortName = truncateName(entry.name, 10)
+          const averageStars = Number(entry.avg_stars || 0).toFixed(1)
           return (
             <div className="leaderboard-entry" key={entry.id || index}>
-              <div className="leaderboard-item-main">
-                <strong>#{index + 1}</strong>
-                {(entry.image_url || "").trim() ? (
-                  <img
-                    src={(entry.image_url || "").trim()}
-                    alt={entry.name || "Establishment"}
-                    className="leaderboard-avatar"
-                  />
-                ) : (
-                  <div className="leaderboard-fallback-avatar">
-                    {(entry.name || "E")?.[0] || "E"}
+              <button className="leaderboard-user-button" onClick={() => onSelectEstablishment?.(entry)} title="View establishment">
+                <div className="leaderboard-item-main">
+                  <strong>#{index + 1}</strong>
+                  <div className="leaderboard-avatar-wrap">
+                    {(entry.image_url || "").trim() ? (
+                      <img
+                        src={(entry.image_url || "").trim()}
+                        alt={entry.name || "Establishment"}
+                        className="leaderboard-avatar"
+                      />
+                    ) : (
+                      <div className="leaderboard-fallback-avatar">
+                        {(entry.name || "E")?.[0] || "E"}
+                      </div>
+                    )}
+                    {medalClass ? (
+                      <span className={`leaderboard-medal ${medalClass}`} aria-label={`Top ${index + 1}`}>
+                        {index + 1}
+                      </span>
+                    ) : null}
                   </div>
-                )}
-                <span>{entry.name || "Establishment"}</span>
-              </div>
+                  <span title={entry.name || "Establishment"}>{shortName}</span>
+                </div>
+              </button>
               <div className="leaderboard-item-meta">
-                <div className="pill">{Number(entry.review_count || 0)} reviews</div>
-                <div className="review-stars leaderboard-stars">
-                  {"★".repeat(stars)}
-                  {"☆".repeat(5 - stars)} ({Number(entry.avg_stars || 0).toFixed(1)})
+                <div className="pill">
+                  {averageStars}
+                  {" "}
+                  ★
                 </div>
               </div>
             </div>
           )
         })
       )}
+      <div style={{ textAlign: "right", marginTop: "16px" }}>
+        <button className="ghost-button" onClick={onViewAll}>
+          All
+        </button>
+      </div>
     </aside>
   )
 }

--- a/repositories/establishmentRepository.js
+++ b/repositories/establishmentRepository.js
@@ -27,7 +27,7 @@ async function listTopReviewedEstablishments({ limit, offset }) {
      FROM establishments e
      JOIN reviews r ON r.establishment_id = e.id
      GROUP BY e.id
-     ORDER BY review_count DESC, avg_stars DESC, e.created_at DESC
+     ORDER BY avg_stars DESC, review_count DESC, e.created_at DESC
      LIMIT $1 OFFSET $2`,
     [limit, offset]
   );


### PR DESCRIPTION
### What changed
- Updated `Top Establishments` sidebar block to support click navigation on each establishment.
- Added click navigation from the full `All` establishments page.
- Implemented a new `EstablishmentDetailPage`:
  - Top section with establishment summary (image, name, location/category, avg stars, total reviews).
  - Bottom section with paginated reviews for that establishment.
- Wired app state and routing flow for `establishment-detail`.
- Added reviews fetch by `establishment_id` (sorted by stars descending) for the detail page.
- Preserved back navigation to the previous context (`reviews` or `top-establishments`).

### Files touched
- `frontend/src/components/TopEstablishmentsPanel.jsx`
- `frontend/src/components/HomeSidebarPanels.jsx`
- `frontend/src/components/FullTopEstablishmentsPage.jsx`
- `frontend/src/components/EstablishmentDetailPage.jsx` (new)
- `frontend/src/App.jsx`

### Validation
- Frontend build passes:
  - `npm --prefix frontend run build`

### Notes
- Existing backend endpoint `GET /reviews` with `establishment_id` was reused; no new API endpoint required.
