### PR TITLE
feat(reviews): add centered search bar with location filter (Lima default + current location)

### DIFF
--- a/controllers/reviewsController.js
+++ b/controllers/reviewsController.js
@@ -540,6 +540,9 @@ async function listReviews(req, res, next) {
     const establishmentId = req.query.establishment_id || null;
     const userId = req.query.user_id || null;
     const sort = req.query.sort || null;
+    const search = req.query.search == null ? '' : String(req.query.search).trim();
+    const location = req.query.location == null ? '' : String(req.query.location).trim();
+    const country = req.query.country == null ? '' : String(req.query.country).trim();
     const rawTag = req.query.tag;
     const tag = typeof rawTag === 'string' ? rawTag.trim() : null;
 
@@ -565,6 +568,15 @@ async function listReviews(req, res, next) {
     if (tag && tag.length > 30) {
       throw new ApiError(400, 'tag must be at most 30 characters');
     }
+    if (search.length > 150) {
+      throw new ApiError(400, 'search must be at most 150 characters');
+    }
+    if (location.length > 120) {
+      throw new ApiError(400, 'location must be at most 120 characters');
+    }
+    if (country.length > 50) {
+      throw new ApiError(400, 'country must be at most 50 characters');
+    }
 
     const result = await reviewService.listReviews({
       page,
@@ -572,6 +584,9 @@ async function listReviews(req, res, next) {
       establishmentId,
       userId,
       sort,
+      search,
+      location,
+      country,
       tag: tag || null,
     });
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -67,7 +67,9 @@
 .hero {
   display: grid;
   gap: 18px;
-  margin-bottom: 30px;
+  margin-bottom: 18px;
+  justify-items: center;
+  text-align: center;
 }
 
 .hero h1 {
@@ -83,11 +85,13 @@
   color: var(--muted);
   font-size: 1.05rem;
   max-width: 640px;
+  margin-inline: auto;
 }
 
 .hero-row {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: center;
   gap: 14px;
 }
 
@@ -1107,6 +1111,96 @@
   display: none;
 }
 
+.reviews-search-wrap {
+  width: min(650px, 92vw);
+  margin: 12px auto 22px;
+  position: relative;
+  z-index: 30;
+}
+
+.reviews-search-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  border: 1px solid rgba(15, 20, 26, 0.12);
+  border-radius: 14px;
+  background: #fff;
+  overflow: visible;
+  box-shadow: 0 14px 28px -24px rgba(15, 20, 26, 0.55);
+}
+
+.reviews-search-input {
+  border: 0;
+  background: transparent;
+  padding: 14px 16px;
+  font-size: 1rem;
+  outline: none;
+}
+
+.reviews-search-location {
+  position: relative;
+}
+
+.reviews-search-location-btn {
+  border: 0;
+  border-left: 1px solid var(--border);
+  background: #fff;
+  color: #3f3f46;
+  padding: 14px 10px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  min-width: 118px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.reviews-search-location-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 220px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 18px 34px -20px rgba(15, 20, 26, 0.45);
+  display: grid;
+  padding: 6px;
+  z-index: 5;
+}
+
+.reviews-search-location-menu button {
+  border: 0;
+  background: transparent;
+  text-align: left;
+  padding: 10px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.93rem;
+}
+
+.reviews-search-location-menu button:hover {
+  background: #f4f6fb;
+}
+
+.reviews-search-submit {
+  border: 0;
+  background: #e74c2e;
+  color: #fff;
+  height: 100%;
+  padding: 0 18px;
+  font-size: 1.1rem;
+  cursor: pointer;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
+}
+
+.reviews-search-error {
+  margin-top: 6px;
+  color: #b91c1c;
+  font-size: 0.85rem;
+  padding-left: 8px;
+}
+
 .wallet-modal-overlay {
   position: fixed;
   inset: 0;
@@ -1508,6 +1602,33 @@
     background: rgba(15, 20, 26, 0.2);
     z-index: 1;
     cursor: default;
+  }
+
+  .reviews-search-bar {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    border-radius: 14px;
+    padding: 0;
+    gap: 0;
+  }
+
+  .reviews-search-input {
+    padding: 12px 12px;
+  }
+
+  .reviews-search-location-btn {
+    border-left: 1px solid var(--border);
+    background: #fff;
+    padding: 12px 10px;
+    min-width: 0;
+  }
+
+  .reviews-search-submit {
+    border-radius: 0;
+    border-top-right-radius: 13px;
+    border-bottom-right-radius: 13px;
+    height: 100%;
+    width: auto;
+    padding: 0 14px;
   }
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,12 @@ const DEFAULT_MAP_VIEW = {
   latitude: -12.0464,
   longitude: -77.0428,
 }
+const DEFAULT_REVIEW_FEED_LOCATION = {
+  mode: "default",
+  location: "Lima",
+  country: "PE",
+  label: "Lima, PE",
+}
 const ESTABLISHMENT_CATEGORIES = [
   "Restaurant",
   "Cafe",
@@ -404,6 +410,14 @@ const toNumberOrNull = (value) => {
   return Number.isFinite(numeric) ? numeric : null
 }
 
+const normalizeCountryCode = (value) => {
+  const normalized = String(value || "").trim().toLowerCase()
+  if (!normalized) return ""
+  if (["pe", "peru", "perú", "republic of peru"].includes(normalized)) return "PE"
+  if (normalized.length === 2) return normalized.toUpperCase()
+  return normalized.toUpperCase()
+}
+
 const isUuid = (value) => /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(String(value || "").trim())
 
 const buildEmbeddedMapUrl = ({ latitude, longitude }) => {
@@ -708,6 +722,7 @@ function App() {
   const activeWalletProviderRef = useRef(null)
   const activeReviewSubmissionIdRef = useRef(null)
   const cancelledReviewSubmissionIdsRef = useRef(new Set())
+  const reviewLocationMenuRef = useRef(null)
 
   const [profile, setProfile] = useState({
     name: "",
@@ -770,6 +785,14 @@ function App() {
   const [reviews, setReviews] = useState([])
   const [reviewsMeta, setReviewsMeta] = useState({ page: 1, page_size: DEFAULT_PAGE_SIZE, total: 0 })
   const [selectedReviewTag, setSelectedReviewTag] = useState("")
+  const [reviewSearchDraft, setReviewSearchDraft] = useState("")
+  const [reviewSearchApplied, setReviewSearchApplied] = useState("")
+  const [reviewFeedLocation, setReviewFeedLocation] = useState({
+    ...DEFAULT_REVIEW_FEED_LOCATION,
+    loading: false,
+    error: "",
+  })
+  const [reviewLocationMenuOpen, setReviewLocationMenuOpen] = useState(false)
   const [leaderboard, setLeaderboard] = useState([])
   const [leaderMeta, setLeaderMeta] = useState({ page: 1, page_size: 5, total: 0 })
   const [fullLeaderboard, setFullLeaderboard] = useState([])
@@ -2423,15 +2446,29 @@ function App() {
     }
   }
 
-  const fetchReviews = async (page = 1, { tag } = {}) => {
+  const fetchReviews = async (page = 1, { tag, search, location, country } = {}) => {
     setLoadingReviews(true)
     const normalizedTag = typeof tag === "string" ? tag.trim() : String(selectedReviewTag || "").trim()
+    const normalizedSearch = typeof search === "string" ? search.trim() : String(reviewSearchApplied || "").trim()
+    const normalizedLocation = typeof location === "string" ? location.trim() : String(reviewFeedLocation.location || "").trim()
+    const normalizedCountry = typeof country === "string"
+      ? normalizeCountryCode(country)
+      : normalizeCountryCode(reviewFeedLocation.country)
     const params = new URLSearchParams({
       page: String(page),
       page_size: String(DEFAULT_PAGE_SIZE),
     })
     if (normalizedTag) {
       params.set("tag", normalizedTag)
+    }
+    if (normalizedSearch) {
+      params.set("search", normalizedSearch)
+    }
+    if (normalizedLocation) {
+      params.set("location", normalizedLocation)
+    }
+    if (normalizedCountry) {
+      params.set("country", normalizedCountry)
     }
     try {
       const result = await apiFetch(`/reviews?${params.toString()}`)
@@ -2454,6 +2491,110 @@ function App() {
   const clearTagFilter = () => {
     setSelectedReviewTag("")
     fetchReviews(1, { tag: "" })
+  }
+
+  const applyReviewSearch = () => {
+    const normalized = String(reviewSearchDraft || "").trim()
+    setReviewSearchApplied(normalized)
+    fetchReviews(1, { search: normalized })
+  }
+
+  const useDefaultReviewLocation = () => {
+    setReviewFeedLocation((prev) => ({
+      ...prev,
+      ...DEFAULT_REVIEW_FEED_LOCATION,
+      loading: false,
+      error: "",
+    }))
+    setReviewLocationMenuOpen(false)
+    fetchReviews(1, {
+      location: DEFAULT_REVIEW_FEED_LOCATION.location,
+      country: DEFAULT_REVIEW_FEED_LOCATION.country,
+    })
+  }
+
+  const useCurrentReviewLocation = async () => {
+    if (!navigator?.geolocation) {
+      setReviewFeedLocation((prev) => ({
+        ...prev,
+        loading: false,
+        error: "Tu navegador no soporta geolocalización.",
+      }))
+      setReviewLocationMenuOpen(false)
+      return
+    }
+
+    setReviewFeedLocation((prev) => ({
+      ...prev,
+      loading: true,
+      error: "",
+    }))
+    setReviewLocationMenuOpen(false)
+    try {
+      const position = await new Promise((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(resolve, reject, {
+          enableHighAccuracy: true,
+          timeout: 12000,
+          maximumAge: 0,
+        })
+      })
+
+      const latitude = toNumberOrNull(position?.coords?.latitude)
+      const longitude = toNumberOrNull(position?.coords?.longitude)
+      if (latitude == null || longitude == null) {
+        throw new Error("No se pudo leer tu ubicación actual.")
+      }
+
+      const params = new URLSearchParams({
+        format: "jsonv2",
+        lat: String(latitude),
+        lon: String(longitude),
+        addressdetails: "1",
+      })
+      const response = await fetch(`${NOMINATIM_REVERSE_URL}?${params.toString()}`, {
+        headers: { "Accept-Language": "es,en" },
+      })
+      if (!response.ok) {
+        throw new Error("No se pudo resolver la ubicación actual.")
+      }
+
+      const data = await response.json()
+      const addr = data?.address || {}
+      const normalizedCountry = normalizeCountryCode(addr?.country_code || addr?.country || "")
+      const normalizedLocation = String(
+        addr?.city ||
+        addr?.town ||
+        addr?.village ||
+        addr?.city_district ||
+        addr?.suburb ||
+        addr?.state ||
+        ""
+      ).trim()
+      const resolvedLocation = normalizedLocation || "Current location"
+      const nextLabel = normalizedCountry
+        ? `${resolvedLocation}, ${normalizedCountry}`
+        : resolvedLocation
+
+      setReviewFeedLocation((prev) => ({
+        ...prev,
+        mode: "current",
+        location: resolvedLocation,
+        country: normalizedCountry,
+        label: nextLabel,
+        loading: false,
+        error: "",
+      }))
+      fetchReviews(1, {
+        location: resolvedLocation,
+        country: normalizedCountry,
+      })
+    } catch (error) {
+      setReviewFeedLocation((prev) => ({
+        ...prev,
+        loading: false,
+        error: error?.message || "No se pudo usar tu ubicación actual.",
+      }))
+    }
   }
 
   const fetchMyReviewStatuses = async () => {
@@ -3626,6 +3767,23 @@ function App() {
     fetchFullTopEstablishments(1)
   }, [activePage])
 
+  useEffect(() => {
+    if (!reviewLocationMenuOpen || typeof window === "undefined") return
+    const handleOutside = (event) => {
+      if (!reviewLocationMenuRef.current?.contains(event.target)) {
+        setReviewLocationMenuOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleOutside)
+    return () => document.removeEventListener("mousedown", handleOutside)
+  }, [reviewLocationMenuOpen])
+
+  useEffect(() => {
+    if (activePage !== "reviews") {
+      setReviewLocationMenuOpen(false)
+    }
+  }, [activePage])
+
   return (
     <div className="app-shell">
       <Header
@@ -3721,7 +3879,6 @@ function App() {
           <>
             <section className="hero">
               <div className="hero-row">
-                <span className="hero-line" />
                 <div>
                   <h1>Las mejores reseñas del año</h1>
                   <p>
@@ -3735,6 +3892,52 @@ function App() {
                 </div>
               )}
             </section>
+            <div className="reviews-search-wrap">
+              <form
+                className="reviews-search-bar"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  applyReviewSearch()
+                }}
+              >
+                <input
+                  className="reviews-search-input"
+                  type="search"
+                  value={reviewSearchDraft}
+                  onChange={(event) => setReviewSearchDraft(event.target.value)}
+                  placeholder="Buscar por establishment, descripción, título, ciudad o dirección..."
+                  aria-label="Buscar reviews"
+                />
+                <div className="reviews-search-location" ref={reviewLocationMenuRef}>
+                  <button
+                    type="button"
+                    className="reviews-search-location-btn"
+                    onClick={() => setReviewLocationMenuOpen((prev) => !prev)}
+                    disabled={reviewFeedLocation.loading}
+                    aria-label="Opciones de ubicación"
+                  >
+                    {reviewFeedLocation.loading ? "Ubicando..." : (reviewFeedLocation.label || DEFAULT_REVIEW_FEED_LOCATION.label)}
+                    {" "}
+                    ▾
+                  </button>
+                  {reviewLocationMenuOpen && (
+                    <div className="reviews-search-location-menu">
+                      <button type="button" onClick={useCurrentReviewLocation}>Current location</button>
+                      <button type="button" onClick={useDefaultReviewLocation}>Lima, PE (default)</button>
+                    </div>
+                  )}
+                </div>
+                <button type="submit" className="reviews-search-submit" aria-label="Buscar">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <circle cx="11" cy="11" r="6.5" stroke="currentColor" strokeWidth="2.2" />
+                    <path d="M16 16L21 21" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+                  </svg>
+                </button>
+              </form>
+              {reviewFeedLocation.error && (
+                <div className="reviews-search-error">{reviewFeedLocation.error}</div>
+              )}
+            </div>
 
             <div className="grid">
               <section className="panel" style={{ gridColumn: "1 / 2" }}>

--- a/repositories/reviewRepository.js
+++ b/repositories/reviewRepository.js
@@ -122,7 +122,17 @@ async function upsertReviewAnchor(dbClient, {
   return result.rows[0] || null;
 }
 
-async function listReviews(dbClient, { limit, offset, establishmentId, userId, sort, tag }) {
+async function listReviews(dbClient, {
+  limit,
+  offset,
+  establishmentId,
+  userId,
+  sort,
+  tag,
+  search,
+  location,
+  country,
+}) {
   const values = [];
   const whereParts = [];
 
@@ -145,6 +155,34 @@ async function listReviews(dbClient, { limit, offset, establishmentId, userId, s
         WHERE lower(trim(t.tag_value)) = lower(trim($${values.length}))
       )`
     );
+  }
+  if (search) {
+    values.push(`%${String(search).toLowerCase()}%`);
+    whereParts.push(
+      `(
+        lower(COALESCE(r.title, '')) LIKE $${values.length}
+        OR lower(COALESCE(r.description, '')) LIKE $${values.length}
+        OR lower(COALESCE(e.name, '')) LIKE $${values.length}
+        OR lower(COALESCE(e.address, '')) LIKE $${values.length}
+        OR lower(COALESCE(e.district, '')) LIKE $${values.length}
+        OR lower(COALESCE(e.state_region, '')) LIKE $${values.length}
+        OR lower(COALESCE(e.country, '')) LIKE $${values.length}
+      )`
+    );
+  }
+  if (location) {
+    values.push(`%${String(location).toLowerCase()}%`);
+    whereParts.push(
+      `(
+        lower(COALESCE(e.district, '')) LIKE $${values.length}
+        OR lower(COALESCE(e.state_region, '')) LIKE $${values.length}
+        OR lower(COALESCE(e.address, '')) LIKE $${values.length}
+      )`
+    );
+  }
+  if (country) {
+    values.push(`%${String(country).toLowerCase()}%`);
+    whereParts.push(`lower(COALESCE(e.country, '')) LIKE $${values.length}`);
   }
 
   const whereClause = whereParts.length > 0 ? `WHERE ${whereParts.join(' AND ')}` : '';
@@ -185,6 +223,7 @@ async function listReviews(dbClient, { limit, offset, establishmentId, userId, s
         '{}'::text[]
       ) AS evidence_images
     FROM reviews r
+    LEFT JOIN establishments e ON e.id = r.establishment_id
     LEFT JOIN users u ON u.id = r.user_id
     LEFT JOIN review_evidence re ON re.review_id = r.id
     LEFT JOIN review_anchors ra ON ra.review_id = r.id
@@ -198,6 +237,7 @@ async function listReviews(dbClient, { limit, offset, establishmentId, userId, s
   const countResult = await dbClient.query(
     `SELECT COUNT(*)::int AS total
      FROM reviews r
+     LEFT JOIN establishments e ON e.id = r.establishment_id
      ${whereClause}`,
     values.slice(0, values.length - 2)
   );

--- a/services/reviewService.js
+++ b/services/reviewService.js
@@ -272,7 +272,7 @@ async function getReviewByIdService(id) {
   return formatReviewResponse(review, review.evidence_images || []);
 }
 
-async function listReviewsService({ page, pageSize, establishmentId, userId, sort, tag }) {
+async function listReviewsService({ page, pageSize, establishmentId, userId, sort, tag, search, location, country }) {
   const offset = (page - 1) * pageSize;
   const { rows, total } = await listReviewsRepo({ query }, {
     limit: pageSize,
@@ -281,6 +281,9 @@ async function listReviewsService({ page, pageSize, establishmentId, userId, sor
     userId,
     sort,
     tag,
+    search,
+    location,
+    country,
   });
 
   const data = rows.map((review) =>


### PR DESCRIPTION
### Summary
This PR introduces a new reviews search feature in the home page:
- Adds a centered search bar below the hero section.
- Supports searching reviews by:
  - establishment name
  - review title
  - review description
  - address / district / state / country
- Sets default location filter to **Lima, PE**.
- Allows switching location filter to **Current location** from the location dropdown.
- Keeps responsive layout in a single horizontal bar and improves spacing around hero/search sections.

### Frontend changes
- Added search UI below hero and above reviews list.
- Centered hero heading/subheading.
- Updated search bar spacing and compact location selector.
- Removed clear (`x`) button as requested.
- Preserved search action with magnifier icon and location dropdown behavior.

### Backend changes
- Extended `/reviews` list filters to accept:
  - `search`
  - `location`
  - `country`
- Added query validation for new params.
- Updated repository filtering logic to include establishment location fields in search matching.

### Notes
- Location defaults to `Lima, PE` unless user selects `Current location`.
- Search input remains the main entry point for textual filtering.

### Testing
- Manual UI verification for:
  - hero centered text
  - search bar placement and responsive behavior
  - location dropdown options and switching
  - search results by title/description/establishment/location terms
