### PR TITLE
feat(reviews): add Global location option to show reviews from all zones

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -47,6 +47,12 @@ const DEFAULT_REVIEW_FEED_LOCATION = {
   country: "PE",
   label: "Lima, PE",
 }
+const GLOBAL_REVIEW_FEED_LOCATION = {
+  mode: "global",
+  location: "",
+  country: "",
+  label: "Global",
+}
 const ESTABLISHMENT_CATEGORIES = [
   "Restaurant",
   "Cafe",
@@ -2573,6 +2579,20 @@ function App() {
     })
   }
 
+  const useGlobalReviewLocation = () => {
+    setReviewFeedLocation((prev) => ({
+      ...prev,
+      ...GLOBAL_REVIEW_FEED_LOCATION,
+      loading: false,
+      error: "",
+    }))
+    setReviewLocationMenuOpen(false)
+    fetchReviews(1, {
+      location: "",
+      country: "",
+    })
+  }
+
   const useCurrentReviewLocation = async () => {
     if (!navigator?.geolocation) {
       setReviewFeedLocation((prev) => ({
@@ -4130,6 +4150,7 @@ function App() {
                   </button>
                   {reviewLocationMenuOpen && (
                     <div className="reviews-search-location-menu">
+                      <button type="button" onClick={useGlobalReviewLocation}>Global</button>
                       <button type="button" onClick={useCurrentReviewLocation}>Current location</button>
                       <button type="button" onClick={useDefaultReviewLocation}>Lima, PE (default)</button>
                     </div>


### PR DESCRIPTION
Este PR agrega una nueva opción **Global** en el selector de ubicación del buscador principal de reviews.  
Al seleccionar esta opción, se eliminan los filtros de `location` y `country`, mostrando reviews de todas las zonas.

### Cambios realizados
- Se añadió la constante `GLOBAL_REVIEW_FEED_LOCATION` en `frontend/src/App.jsx`.
- Se implementó `useGlobalReviewLocation` para:
  - actualizar el estado del feed a modo global,
  - cerrar el menú de ubicación,
  - ejecutar la búsqueda sin filtros geográficos (`location: ""`, `country: ""`).
- Se agregó el botón **Global** al menú de ubicación, junto a:
  - `Current location`
  - `Lima, PE (default)`.

### Impacto funcional
- Los usuarios ahora pueden alternar entre:
  - ubicación actual,
  - ubicación por defecto (Lima, PE),
  - vista global (todas las zonas).
- No se modifican endpoints ni contratos de backend.

### Verificación
- Build de frontend ejecutado con éxito:
  - `npm --prefix frontend run build`

### Archivos modificados
- `frontend/src/App.jsx`
