### PR TITLE
feat(reviews): habilitar vista global en buscador de reviews (todas las zonas)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -47,6 +47,12 @@ const DEFAULT_REVIEW_FEED_LOCATION = {
   country: "PE",
   label: "Lima, PE",
 }
+const GLOBAL_REVIEW_FEED_LOCATION = {
+  mode: "global",
+  location: "",
+  country: "",
+  label: "Global",
+}
 const ESTABLISHMENT_CATEGORIES = [
   "Restaurant",
   "Cafe",
@@ -2573,6 +2579,20 @@ function App() {
     })
   }
 
+  const useGlobalReviewLocation = () => {
+    setReviewFeedLocation((prev) => ({
+      ...prev,
+      ...GLOBAL_REVIEW_FEED_LOCATION,
+      loading: false,
+      error: "",
+    }))
+    setReviewLocationMenuOpen(false)
+    fetchReviews(1, {
+      location: "",
+      country: "",
+    })
+  }
+
   const useCurrentReviewLocation = async () => {
     if (!navigator?.geolocation) {
       setReviewFeedLocation((prev) => ({
@@ -4130,6 +4150,7 @@ function App() {
                   </button>
                   {reviewLocationMenuOpen && (
                     <div className="reviews-search-location-menu">
+                      <button type="button" onClick={useGlobalReviewLocation}>Global</button>
                       <button type="button" onClick={useCurrentReviewLocation}>Current location</button>
                       <button type="button" onClick={useDefaultReviewLocation}>Lima, PE (default)</button>
                     </div>


### PR DESCRIPTION
### Resumen general
Este PR agrega una nueva opción **Global** en el selector de ubicación del buscador principal de reviews, permitiendo ver reseñas de todas las zonas sin filtros geográficos.

### Cambios realizados
- Se añadió `GLOBAL_REVIEW_FEED_LOCATION` en `frontend/src/App.jsx`.
- Se implementó `useGlobalReviewLocation` para:
  - cambiar el modo del feed a global,
  - limpiar los filtros `location` y `country`,
  - recargar reviews sin restricciones geográficas.
- Se agregó **Global** al menú de ubicación, junto a:
  - `Current location`
  - `Lima, PE (default)`.

### Impacto funcional
- El usuario ahora puede alternar rápidamente entre:
  - ubicación actual,
  - ubicación por defecto (Lima, PE),
  - vista global (todas las zonas).
- No hubo cambios en backend ni en contratos de API.

### Validación
- Build de frontend ejecutado correctamente:
  - `npm --prefix frontend run build`

### Archivos modificados
- `frontend/src/App.jsx`
